### PR TITLE
Add missing `acquirer_reference_number` field

### DIFF
--- a/payments/payment.go
+++ b/payments/payment.go
@@ -430,6 +430,7 @@ type (
 		Aft                      *bool              `json:"aft,omitempty"`
 		DLocal                   *DLocal            `json:"dlocal,omitempty"`
 		AcquirerTransactionID    string             `json:"acquirer_transaction_id,omitempty"`
+		AcquirerReferenceNumber  string             `json:"acquirer_reference_number,omitempty"`
 		RetrievalReferenceNumber string             `json:"retrieval_reference_number,omitempty"`
 		SenderInformation        *SenderInformation `json:"senderInformation,omitempty"`
 	}


### PR DESCRIPTION
Seen in [get payment actions](https://api-reference.checkout.com/#operation/getPaymentActions)