### PR TITLE
Added support for get payment lists (CS1/CS2)

### DIFF
--- a/payments/abc/client.go
+++ b/payments/abc/client.go
@@ -40,6 +40,26 @@ func (c *Client) RequestPayment(request PaymentRequest, idempotencyKey *string) 
 	return &response, nil
 }
 
+func (c *Client) RequestPaymentList(request payments.QueryRequest) (*GetPaymentListResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := common.BuildQueryPath(payments.PathPayments, request)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPaymentListResponse
+	err = c.apiClient.Get(url, auth, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
 func (c *Client) RequestPayout(request PayoutRequest, idempotencyKey *string) (*PaymentResponse, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKey)
 	if err != nil {

--- a/payments/abc/client_test.go
+++ b/payments/abc/client_test.go
@@ -156,6 +156,136 @@ func TestRequestPayment(t *testing.T) {
 	}
 }
 
+func TestRequestPaymentList(t *testing.T) {
+	var (
+		httpMetadata = common.HttpMetadata{
+			Status:     "200 OK",
+			StatusCode: http.StatusOK,
+		}
+
+		queryRequest = payments.QueryRequest{
+			Limit:     1,
+			Skip:      0,
+			Reference: "reference",
+		}
+
+		paymentResponse = GetPaymentResponse{
+			HttpMetadata: httpMetadata,
+			Id:           paymentId,
+			Amount:       amount,
+			Currency:     currency,
+			Source: &SourceResponse{
+				ResponseCardSource: &ResponseCardSource{
+					Type: payments.CardSource,
+				},
+			},
+			Reference: reference,
+		}
+
+		paymentListResponse = GetPaymentListResponse{
+			HttpMetadata: httpMetadata,
+			Limit:        1,
+			Skip:         0,
+			TotalCount:   1,
+			Data:         []GetPaymentResponse{paymentResponse},
+		}
+	)
+
+	cases := []struct {
+		name             string
+		queryRequest     payments.QueryRequest
+		getAuthorization func(*mock.Mock) mock.Call
+		apiGet           func(*mock.Mock) mock.Call
+		checker          func(*GetPaymentListResponse, error)
+	}{
+		{
+			name:         "when reference is correct then return a payment list",
+			queryRequest: queryRequest,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				return *m.On("Get", mock.Anything, mock.Anything, mock.Anything).
+					Return(nil).
+					Run(func(args mock.Arguments) {
+						respMapping := args.Get(2).(*GetPaymentListResponse)
+						*respMapping = paymentListResponse
+					})
+			},
+			checker: func(response *GetPaymentListResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+				assert.Equal(t, paymentListResponse.Limit, response.Limit)
+				assert.Equal(t, paymentListResponse.Skip, response.Skip)
+				assert.Equal(t, paymentListResponse.TotalCount, response.TotalCount)
+				assert.Equal(t, paymentListResponse.Data[0].Id, response.Data[0].Id)
+				assert.Equal(t, paymentListResponse.Data[0].Amount, response.Data[0].Amount)
+				assert.Equal(t, paymentListResponse.Data[0].Currency, response.Data[0].Currency)
+				assert.Equal(t, paymentListResponse.Data[0].Reference, response.Data[0].Reference)
+			},
+		},
+		{
+			name:         "when credentials invalid then return error",
+			queryRequest: queryRequest,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(nil, errors.CheckoutAuthorizationError("Invalid authorization type"))
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				return *m.On("Get", mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+			},
+			checker: func(response *GetPaymentListResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAuthorizationError)
+				assert.Equal(t, "Invalid authorization type", chkErr.Error())
+			},
+		},
+		{
+			name:         "when reference not found then return error",
+			queryRequest: queryRequest,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				return *m.On("Get", mock.Anything, mock.Anything, mock.Anything).
+					Return(
+						errors.CheckoutAPIError{
+							StatusCode: http.StatusNotFound,
+							Status:     "404 Not Found",
+						})
+			},
+			checker: func(response *GetPaymentListResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+				assert.Equal(t, "404 Not Found", chkErr.Status)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiClient := new(mocks.ApiClientMock)
+			credentials := new(mocks.CredentialsMock)
+			environment := new(mocks.EnvironmentMock)
+
+			tc.getAuthorization(&credentials.Mock)
+			tc.apiGet(&apiClient.Mock)
+
+			configuration := configuration.NewConfiguration(credentials, environment, &http.Client{})
+			client := NewClient(configuration, apiClient)
+
+			tc.checker(client.RequestPaymentList(tc.queryRequest))
+		})
+	}
+}
+
 func TestRequestPayout(t *testing.T) {
 	var (
 		cardDestination = NewRequestCardDestination()

--- a/payments/abc/payments.go
+++ b/payments/abc/payments.go
@@ -147,6 +147,14 @@ type (
 		Metadata        map[string]interface{} `json:"metadata,omitempty"`
 		Links           map[string]common.Link `json:"_links"`
 	}
+
+	GetPaymentListResponse struct {
+		HttpMetadata common.HttpMetadata
+		Limit        int                  `json:"limit,omitempty"`
+		Skip         int                  `json:"skip,omitempty"`
+		TotalCount   int                  `json:"total_count,omitempty"`
+		Data         []GetPaymentResponse `json:"data,omitempty"`
+	}
 )
 
 func (p *GetPaymentActionsResponse) UnmarshalJSON(data []byte) error {

--- a/payments/nas/client.go
+++ b/payments/nas/client.go
@@ -40,6 +40,26 @@ func (c *Client) RequestPayment(request PaymentRequest, idempotencyKey *string) 
 	return &response, nil
 }
 
+func (c *Client) RequestPaymentList(request payments.QueryRequest) (*GetPaymentListResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := common.BuildQueryPath(payments.PathPayments, request)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetPaymentListResponse
+	err = c.apiClient.Get(url, auth, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
 func (c *Client) RequestPayout(request PayoutRequest, idempotencyKey *string) (*PayoutResponse, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {

--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -245,6 +245,14 @@ type (
 		AmountAllocations []common.AmountAllocations   `json:"amount_allocations,omitempty"`
 		Links             map[string]common.Link       `json:"_links"`
 	}
+
+	GetPaymentListResponse struct {
+		HttpMetadata common.HttpMetadata
+		Limit        int                  `json:"limit,omitempty"`
+		Skip         int                  `json:"skip,omitempty"`
+		TotalCount   int                  `json:"total_count,omitempty"`
+		Data         []GetPaymentResponse `json:"data,omitempty"`
+	}
 )
 
 func (p *GetPaymentActionsResponse) UnmarshalJSON(data []byte) error {

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -387,6 +387,12 @@ type (
 		Reference string                 `json:"reference,omitempty"`
 		Metadata  map[string]interface{} `json:"metadata,omitempty"`
 	}
+
+	QueryRequest struct {
+		Limit     int    `url:"limit,10"`
+		Skip      int    `url:"skip,0"`
+		Reference string `url:"reference,omitempty"`
+	}
 )
 
 //Response

--- a/test/payments_request_previous_test.go
+++ b/test/payments_request_previous_test.go
@@ -30,44 +30,33 @@ func TestRequestCardPaymentPrevious(t *testing.T) {
 	assert.NotEmpty(t, paymentResponse.Currency)
 	assert.Nil(t, paymentResponse.ThreeDs)
 
-	//Source
-	assert.NotEmpty(t, paymentResponse.Source)
-	responseCardSource := paymentResponse.Source.ResponseCardSource
-	assert.NotEmpty(t, payments.CardSource, responseCardSource.Type)
-	assert.NotEmpty(t, responseCardSource.Id)
-	assert.NotEmpty(t, responseCardSource.AvsCheck)
-	assert.NotEmpty(t, responseCardSource.CvvCheck)
-	assert.NotEmpty(t, responseCardSource.Bin)
-	assert.NotEmpty(t, responseCardSource.ExpiryYear)
-	assert.NotEmpty(t, responseCardSource.ExpiryMonth)
-	assert.NotEmpty(t, responseCardSource.Last4)
-	assert.NotEmpty(t, responseCardSource.Name)
-	assert.NotEmpty(t, responseCardSource.FastFunds)
-	assert.NotEmpty(t, responseCardSource.Fingerprint)
-	assert.True(t, responseCardSource.Payouts)
+	paymentCommonAssertionsPrevious(t, paymentResponse)
 
-	//Customer
-	assert.NotEmpty(t, paymentResponse.Customer)
-	customer := paymentResponse.Customer
-	assert.NotEmpty(t, customer)
-	assert.NotEmpty(t, customer.Id)
-	assert.NotEmpty(t, customer.Name)
+}
 
-	//Processing
-	assert.NotEmpty(t, paymentResponse.Processing)
-	processing := paymentResponse.Processing
-	assert.NotEmpty(t, processing)
-	assert.NotEmpty(t, processing.AcquirerTransactionId)
-	assert.NotEmpty(t, processing.RetrievalReferenceNumber)
+func TestRequestPaymentListPrevious(t *testing.T) {
 
-	//Risk
-	assert.False(t, paymentResponse.Risk.Flagged)
+	paymentResponse := makeCardPaymentPrevious(t, false, 10)
 
-	//Links
-	assert.NotEmpty(t, paymentResponse.Links["self"])
-	assert.NotEmpty(t, paymentResponse.Links["actions"])
-	assert.NotEmpty(t, paymentResponse.Links["capture"])
-	assert.NotEmpty(t, paymentResponse.Links["void"])
+	queryRequest := payments.QueryRequest{
+		Limit:     1,
+		Skip:      0,
+		Reference: paymentResponse.Reference,
+	}
+
+	paymentListResponse, err := PreviousApi().Payments.RequestPaymentList(queryRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentListResponse)
+	assert.Equal(t, 200, paymentListResponse.HttpMetadata.StatusCode)
+	assert.Equal(t, 1, paymentListResponse.Limit)
+	assert.Equal(t, 0, paymentListResponse.Skip)
+	assert.NotNil(t, paymentListResponse.TotalCount)
+	assert.NotNil(t, paymentListResponse.Data)
+	assert.NotNil(t, paymentListResponse.Data[0].Id)
+	assert.NotNil(t, paymentListResponse.Data[0].RequestedOn)
+	assert.NotNil(t, paymentListResponse.Data[0].Source)
+
+	paymentCommonAssertionsPrevious(t, paymentResponse)
 
 }
 
@@ -419,4 +408,45 @@ func makeCardTokenPaymentPrevious(t *testing.T) *abc.PaymentResponse {
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	return response
+}
+
+func paymentCommonAssertionsPrevious(t *testing.T, paymentResponse *abc.PaymentResponse) {
+	//Source
+	assert.NotEmpty(t, paymentResponse.Source)
+	responseCardSource := paymentResponse.Source.ResponseCardSource
+	assert.NotEmpty(t, payments.CardSource, responseCardSource.Type)
+	assert.NotEmpty(t, responseCardSource.Id)
+	assert.NotEmpty(t, responseCardSource.AvsCheck)
+	assert.NotEmpty(t, responseCardSource.CvvCheck)
+	assert.NotEmpty(t, responseCardSource.Bin)
+	assert.NotEmpty(t, responseCardSource.ExpiryYear)
+	assert.NotEmpty(t, responseCardSource.ExpiryMonth)
+	assert.NotEmpty(t, responseCardSource.Last4)
+	assert.NotEmpty(t, responseCardSource.Name)
+	assert.NotEmpty(t, responseCardSource.FastFunds)
+	assert.NotEmpty(t, responseCardSource.Fingerprint)
+	assert.True(t, responseCardSource.Payouts)
+
+	//Customer
+	assert.NotEmpty(t, paymentResponse.Customer)
+	customer := paymentResponse.Customer
+	assert.NotEmpty(t, customer)
+	assert.NotEmpty(t, customer.Id)
+	assert.NotEmpty(t, customer.Name)
+
+	//Processing
+	assert.NotEmpty(t, paymentResponse.Processing)
+	processing := paymentResponse.Processing
+	assert.NotEmpty(t, processing)
+	assert.NotEmpty(t, processing.AcquirerTransactionId)
+	assert.NotEmpty(t, processing.RetrievalReferenceNumber)
+
+	//Risk
+	assert.False(t, paymentResponse.Risk.Flagged)
+
+	//Links
+	assert.NotEmpty(t, paymentResponse.Links["self"])
+	assert.NotEmpty(t, paymentResponse.Links["actions"])
+	assert.NotEmpty(t, paymentResponse.Links["capture"])
+	assert.NotEmpty(t, paymentResponse.Links["void"])
 }

--- a/test/payments_request_test.go
+++ b/test/payments_request_test.go
@@ -30,57 +30,7 @@ func TestRequestCardPayment(t *testing.T) {
 	assert.NotEmpty(t, paymentResponse.Currency)
 	assert.Nil(t, paymentResponse.ThreeDs)
 
-	//Source
-	assert.NotEmpty(t, paymentResponse.Source)
-	responseCardSource := paymentResponse.Source.ResponseCardSource
-	assert.NotEmpty(t, payments.CardSource, responseCardSource.Type)
-	assert.NotEmpty(t, responseCardSource.Id)
-	assert.NotEmpty(t, responseCardSource.AvsCheck)
-	assert.NotEmpty(t, responseCardSource.CvvCheck)
-	assert.NotEmpty(t, responseCardSource.Bin)
-	assert.NotEmpty(t, common.Consumer, responseCardSource.CardCategory)
-	assert.NotEmpty(t, common.Credit, responseCardSource.CardType)
-	assert.NotEmpty(t, responseCardSource.ExpiryYear)
-	assert.NotEmpty(t, responseCardSource.ExpiryMonth)
-	assert.NotEmpty(t, responseCardSource.Last4)
-	assert.NotEmpty(t, responseCardSource.Name)
-	assert.NotEmpty(t, responseCardSource.Fingerprint)
-	assert.NotEmpty(t, responseCardSource.ProductId)
-	assert.NotEmpty(t, responseCardSource.ProductType)
-
-	//Customer
-	assert.NotEmpty(t, paymentResponse.Customer)
-	customer := paymentResponse.Customer
-	assert.NotEmpty(t, customer)
-	assert.NotEmpty(t, customer.Id)
-	assert.NotEmpty(t, customer.Name)
-	assert.NotEmpty(t, customer.Email)
-
-	//Processing
-	assert.NotEmpty(t, paymentResponse.Processing)
-	processing := paymentResponse.Processing
-	assert.NotEmpty(t, processing)
-	assert.NotEmpty(t, processing.AcquirerTransactionId)
-	assert.NotEmpty(t, processing.RetrievalReferenceNumber)
-
-	//Risk
-	assert.False(t, paymentResponse.Risk.Flagged)
-
-	//Balances
-	assert.NotEmpty(t, paymentResponse.Balances)
-	assert.Equal(t, 10, paymentResponse.Balances.TotalAuthorized)
-	assert.Equal(t, 0, paymentResponse.Balances.TotalCaptured)
-	assert.Equal(t, 0, paymentResponse.Balances.TotalRefunded)
-	assert.Equal(t, 0, paymentResponse.Balances.TotalVoided)
-	assert.Equal(t, 10, paymentResponse.Balances.AvailableToCapture)
-	assert.Equal(t, 0, paymentResponse.Balances.AvailableToRefund)
-	assert.Equal(t, 10, paymentResponse.Balances.AvailableToVoid)
-
-	//Links
-	assert.NotEmpty(t, paymentResponse.Links["self"])
-	assert.NotEmpty(t, paymentResponse.Links["actions"])
-	assert.NotEmpty(t, paymentResponse.Links["capture"])
-	assert.NotEmpty(t, paymentResponse.Links["void"])
+	paymentCommonAssertions(t, paymentResponse)
 
 }
 
@@ -167,6 +117,30 @@ func TestMakeCardVerification(t *testing.T) {
 	assert.NotEmpty(t, paymentResponse.Links["actions"])
 	assert.Empty(t, paymentResponse.Links["capture"])
 	assert.Empty(t, paymentResponse.Links["void"])
+
+}
+
+func TestRequestPaymentList(t *testing.T) {
+
+	paymentResponse := makeCardPayment(t, false, 10)
+
+	queryRequest := payments.QueryRequest{
+		Limit:     1,
+		Skip:      0,
+		Reference: paymentResponse.Reference,
+	}
+
+	paymentListResponse, err := DefaultApi().Payments.RequestPaymentList(queryRequest)
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentListResponse)
+	assert.Equal(t, 200, paymentListResponse.HttpMetadata.StatusCode)
+	assert.Equal(t, 1, paymentListResponse.Limit)
+	assert.Equal(t, 0, paymentListResponse.Skip)
+	assert.NotNil(t, paymentListResponse.TotalCount)
+	assert.NotNil(t, paymentListResponse.Data)
+	assert.NotNil(t, paymentListResponse.Data[0].Source)
+
+	paymentCommonAssertions(t, paymentResponse)
 
 }
 
@@ -483,4 +457,59 @@ func makeCardTokenPayment(t *testing.T) *nas.PaymentResponse {
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	return response
+}
+
+func paymentCommonAssertions(t *testing.T, paymentResponse *nas.PaymentResponse) {
+
+	//Source
+	assert.NotEmpty(t, paymentResponse.Source)
+	responseCardSource := paymentResponse.Source.ResponseCardSource
+	assert.NotEmpty(t, payments.CardSource, responseCardSource.Type)
+	assert.NotEmpty(t, responseCardSource.Id)
+	assert.NotEmpty(t, responseCardSource.AvsCheck)
+	assert.NotEmpty(t, responseCardSource.CvvCheck)
+	assert.NotEmpty(t, responseCardSource.Bin)
+	assert.NotEmpty(t, common.Consumer, responseCardSource.CardCategory)
+	assert.NotEmpty(t, common.Credit, responseCardSource.CardType)
+	assert.NotEmpty(t, responseCardSource.ExpiryYear)
+	assert.NotEmpty(t, responseCardSource.ExpiryMonth)
+	assert.NotEmpty(t, responseCardSource.Last4)
+	assert.NotEmpty(t, responseCardSource.Name)
+	assert.NotEmpty(t, responseCardSource.Fingerprint)
+	assert.NotEmpty(t, responseCardSource.ProductId)
+	assert.NotEmpty(t, responseCardSource.ProductType)
+
+	//Customer
+	assert.NotEmpty(t, paymentResponse.Customer)
+	customer := paymentResponse.Customer
+	assert.NotEmpty(t, customer)
+	assert.NotEmpty(t, customer.Id)
+	assert.NotEmpty(t, customer.Name)
+	assert.NotEmpty(t, customer.Email)
+
+	//Processing
+	assert.NotEmpty(t, paymentResponse.Processing)
+	processing := paymentResponse.Processing
+	assert.NotEmpty(t, processing)
+	assert.NotEmpty(t, processing.AcquirerTransactionId)
+	assert.NotEmpty(t, processing.RetrievalReferenceNumber)
+
+	//Risk
+	assert.False(t, paymentResponse.Risk.Flagged)
+
+	//Balances
+	assert.NotEmpty(t, paymentResponse.Balances)
+	assert.Equal(t, 10, paymentResponse.Balances.TotalAuthorized)
+	assert.Equal(t, 0, paymentResponse.Balances.TotalCaptured)
+	assert.Equal(t, 0, paymentResponse.Balances.TotalRefunded)
+	assert.Equal(t, 0, paymentResponse.Balances.TotalVoided)
+	assert.Equal(t, 10, paymentResponse.Balances.AvailableToCapture)
+	assert.Equal(t, 0, paymentResponse.Balances.AvailableToRefund)
+	assert.Equal(t, 10, paymentResponse.Balances.AvailableToVoid)
+
+	//Links
+	assert.NotEmpty(t, paymentResponse.Links["self"])
+	assert.NotEmpty(t, paymentResponse.Links["actions"])
+	assert.NotEmpty(t, paymentResponse.Links["capture"])
+	assert.NotEmpty(t, paymentResponse.Links["void"])
 }


### PR DESCRIPTION
## Modifications
Added support for get payment lists (CS1/CS2)

## API Reference
CS1: https://api-reference.checkout.com/previous/#operation/getPayments
CS2: https://api-reference.checkout.com/#tag/Payments/paths/~1payments/get