### PR TITLE
Api Updates

### DIFF
--- a/accounts/client.go
+++ b/accounts/client.go
@@ -218,6 +218,29 @@ func (c *Client) RetrievePaymentInstrumentDetails(
 	return &response, nil
 }
 
+func (c *Client) UpdatePaymentInstrumentDetails(
+	entityId, instrumentId string,
+	request UpdatePaymentInstrumentRequest,
+) (*common.IdResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response common.IdResponse
+	err = c.apiClient.Patch(
+		common.BuildPath(accountsPath, entitiesPath, entityId, paymentInstrumentsPath, instrumentId),
+		auth,
+		request,
+		&response,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
 func (c *Client) RetrievePayoutSchedule(entityId string) (*PayoutSchedule, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {

--- a/accounts/instrument_details.go
+++ b/accounts/instrument_details.go
@@ -58,6 +58,11 @@ type (
 	PaymentInstrumentsQuery struct {
 		Status InstrumentStatus `json:"status,omitempty"`
 	}
+
+	UpdatePaymentInstrumentRequest struct {
+		Label   string `json:"label,omitempty"`
+		Default bool   `json:"default,omitempty"`
+	}
 )
 
 func (s *InstrumentDetailsFasterPayments) GetType() string {

--- a/balances/client.go
+++ b/balances/client.go
@@ -19,7 +19,7 @@ func NewClient(configuration *configuration.Configuration, apiClient client.Http
 }
 
 func (c *Client) RetrieveEntityBalances(entityId string, query QueryFilter) (*QueryResponse, error) {
-	auth, err := c.configuration.Credentials.GetAuthorization(configuration.OAuth)
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {
 		return nil, err
 	}

--- a/configuration/oauth_scopes.go
+++ b/configuration/oauth_scopes.go
@@ -39,7 +39,7 @@ const (
 	MiddlewarePaymentContext    = "middleware:payment-context"
 	MiddlewareMerchantsSecret   = "middleware:merchants-secret"
 	MiddlewareMerchantsPublic   = "middleware:merchants-public"
-	Reporting                   = "reporting"
-	ReportingView               = "reporting:view"
+	Reports                     = "reports"
+	ReportsView                 = "reports:view"
 	VaultCardMetadata           = "vault:card-metadata"
 )

--- a/payments/nas/sources/apm/apm.go
+++ b/payments/nas/sources/apm/apm.go
@@ -66,6 +66,11 @@ type (
 		Type payments.SourceType `json:"type,omitempty"`
 	}
 
+	requestCvConnectSource struct {
+		Type           payments.SourceType `json:"type,omitempty"`
+		BillingAddress *common.Address     `json:"billing_address,omitempty"`
+	}
+
 	requestEpsSource struct {
 		Type    payments.SourceType `json:"type,omitempty"`
 		Purpose string              `json:"purpose,omitempty"`
@@ -92,6 +97,11 @@ type (
 		Description string              `json:"description,omitempty"`
 		Bic         string              `json:"bic,omitempty"`
 		Language    string              `json:"language,omitempty"`
+	}
+
+	requestIllicadoSource struct {
+		Type           payments.SourceType `json:"type,omitempty"`
+		BillingAddress *common.Address     `json:"billing_address,omitempty"`
 	}
 
 	requestKlarnaSource struct {
@@ -165,6 +175,11 @@ type (
 		BillingAddress *common.Address     `json:"billing_address,omitempty"`
 	}
 
+	requestTrustlySource struct {
+		Type           payments.SourceType `json:"type,omitempty"`
+		BillingAddress *common.Address     `json:"billing_address,omitempty"`
+	}
+
 	requestWeChatPaySource struct {
 		Type           payments.SourceType `json:"type,omitempty"`
 		BillingAddress *common.Address     `json:"billing_address,omitempty"`
@@ -219,6 +234,10 @@ func NewRequestBenefitSource() *requestBenefitSource {
 	return &requestBenefitSource{Type: payments.Benefit}
 }
 
+func NewRequestCvConnectSource() *requestCvConnectSource {
+	return &requestCvConnectSource{Type: payments.CvConnectSource}
+}
+
 func NewRequestEpsSource() *requestEpsSource {
 	return &requestEpsSource{Type: payments.EpsSource}
 }
@@ -233,6 +252,10 @@ func NewRequestGiropaySource() *requestGiropaySource {
 
 func NewRequestIdealSource() *requestIdealSource {
 	return &requestIdealSource{Type: payments.IdealSource}
+}
+
+func NewRequestIllicadoSource() *requestIllicadoSource {
+	return &requestIllicadoSource{Type: payments.IllicadoSource}
 }
 
 func NewRequestKlarnaSource() *requestKlarnaSource {
@@ -279,6 +302,10 @@ func NewRequestTamaraSource() *requestTamaraSource {
 	return &requestTamaraSource{Type: payments.TamaraSource}
 }
 
+func NewRequestTrustlySource() *requestTrustlySource {
+	return &requestTrustlySource{Type: payments.TrustlySource}
+}
+
 func NewRequestWeChatPaySource() *requestWeChatPaySource {
 	return &requestWeChatPaySource{Type: payments.Wechatpay}
 }
@@ -303,6 +330,10 @@ func (s *requestBenefitSource) GetType() payments.SourceType {
 	return s.Type
 }
 
+func (s *requestCvConnectSource) GetType() payments.SourceType {
+	return s.Type
+}
+
 func (s *requestEpsSource) GetType() payments.SourceType {
 	return s.Type
 }
@@ -316,6 +347,10 @@ func (s *requestGiropaySource) GetType() payments.SourceType {
 }
 
 func (s *requestIdealSource) GetType() payments.SourceType {
+	return s.Type
+}
+
+func (s *requestIllicadoSource) GetType() payments.SourceType {
 	return s.Type
 }
 
@@ -360,6 +395,10 @@ func (s *requestStcPaySource) GetType() payments.SourceType {
 }
 
 func (s *requestTamaraSource) GetType() payments.SourceType {
+	return s.Type
+}
+
+func (s *requestTrustlySource) GetType() payments.SourceType {
 	return s.Type
 }
 

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -426,17 +426,24 @@ type (
 	}
 
 	ProcessingData struct {
-		PreferredScheme                 PreferredSchema                  `json:"preferred_scheme,omitempty"`
-		AppId                           string                           `json:"app_id,omitempty"`
-		PartnerCustomerId               string                           `json:"partner_customer_id,omitempty"`
-		PartnerPaymentId                string                           `json:"partner_payment_id,omitempty"`
-		TaxAmount                       int64                            `json:"tax_amount,omitempty"`
-		PurchaseCountry                 common.Country                   `json:"purchase_country,omitempty"`
-		Locale                          string                           `json:"locale,omitempty"`
-		PartnerOrderId                  string                           `json:"partner_order_id,omitempty"`
-		FraudStatus                     string                           `json:"fraud_status,omitempty"`
-		ProviderAuthorizedPaymentMethod *ProviderAuthorizedPaymentMethod `json:"provider_authorized_payment_method,omitempty"`
-		CustomPaymentMethodIds          []string                         `json:"custom_payment_method_ids,omitempty"`
+		PreferredScheme                  PreferredSchema                  `json:"preferred_scheme,omitempty"`
+		AppId                            string                           `json:"app_id,omitempty"`
+		PartnerCustomerId                string                           `json:"partner_customer_id,omitempty"`
+		PartnerPaymentId                 string                           `json:"partner_payment_id,omitempty"`
+		TaxAmount                        int64                            `json:"tax_amount,omitempty"`
+		PurchaseCountry                  common.Country                   `json:"purchase_country,omitempty"`
+		Locale                           string                           `json:"locale,omitempty"`
+		RetrievalReferenceNumber         string                           `json:"retrieval_reference_number,omitempty"`
+		PartnerOrderId                   string                           `json:"partner_order_id,omitempty"`
+		PartnerStatus                    string                           `json:"partner_status,omitempty"`
+		PartnerTransactionId             string                           `json:"partner_transaction_id,omitempty"`
+		PartnerErrorCodes                string                           `json:"partner_error_codes,omitempty"`
+		PartnerErrorMessage              string                           `json:"partner_error_message,omitempty"`
+		PartnerAuthorizationCode         string                           `json:"partner_authorization_code,omitempty"`
+		PartnerAuthorizationResponseCode string                           `json:"partner_authorization_response_code,omitempty"`
+		FraudStatus                      string                           `json:"fraud_status,omitempty"`
+		ProviderAuthorizedPaymentMethod  *ProviderAuthorizedPaymentMethod `json:"provider_authorized_payment_method,omitempty"`
+		CustomPaymentMethodIds           []string                         `json:"custom_payment_method_ids,omitempty"`
 	}
 
 	ProviderAuthorizedPaymentMethod struct {

--- a/payments/sources.go
+++ b/payments/sources.go
@@ -49,6 +49,9 @@ const (
 	CurrencyAccountSource SourceType = "currency_account"
 	EntitySource          SourceType = "entity"
 	TamaraSource          SourceType = "tamara"
+	CvConnectSource       SourceType = "cvconnect"
+	IllicadoSource        SourceType = "illicado"
+	TrustlySource         SourceType = "trustly"
 )
 
 type (

--- a/test/payments_request_apm_test.go
+++ b/test/payments_request_apm_test.go
@@ -48,6 +48,26 @@ func TestRequestPaymentsAPM(t *testing.T) {
 			},
 		},
 		{
+			name: "test CvConnect source for request payment",
+			request: nas.PaymentRequest{
+				Source:      apm.NewRequestCvConnectSource(),
+				Amount:      100,
+				Currency:    common.EUR,
+				Capture:     true,
+				Reference:   Reference,
+				Description: Description,
+				SuccessUrl:  SuccessUrl,
+				FailureUrl:  FailureUrl,
+			},
+			checkForPaymentRequest: func(response *nas.PaymentResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				ckoErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnprocessableEntity, ckoErr.StatusCode)
+				assert.Equal(t, "payee_not_onboarded", ckoErr.Data.ErrorCodes[0])
+			},
+		},
+		{
 			name: "test Ideal source for request payment",
 			request: nas.PaymentRequest{
 				Source:      getIdealSourceRequest(),
@@ -76,6 +96,26 @@ func TestRequestPaymentsAPM(t *testing.T) {
 				assert.NotNil(t, response.Description)
 				assert.Equal(t, Description, response.Description)
 				assert.NotNil(t, response.Customer)
+			},
+		},
+		{
+			name: "test Illicado source for request payment",
+			request: nas.PaymentRequest{
+				Source:      apm.NewRequestIllicadoSource(),
+				Amount:      100,
+				Currency:    common.EUR,
+				Capture:     true,
+				Reference:   Reference,
+				Description: Description,
+				SuccessUrl:  SuccessUrl,
+				FailureUrl:  FailureUrl,
+			},
+			checkForPaymentRequest: func(response *nas.PaymentResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				ckoErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnprocessableEntity, ckoErr.StatusCode)
+				assert.Equal(t, "payee_not_onboarded", ckoErr.Data.ErrorCodes[0])
 			},
 		},
 		{
@@ -154,6 +194,26 @@ func TestRequestPaymentsAPM(t *testing.T) {
 				},
 				SuccessUrl: SuccessUrl,
 				FailureUrl: FailureUrl,
+			},
+			checkForPaymentRequest: func(response *nas.PaymentResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				ckoErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnprocessableEntity, ckoErr.StatusCode)
+				assert.Equal(t, "payee_not_onboarded", ckoErr.Data.ErrorCodes[0])
+			},
+		},
+		{
+			name: "test Trustly source for request payment",
+			request: nas.PaymentRequest{
+				Source:      apm.NewRequestTrustlySource(),
+				Amount:      100,
+				Currency:    common.EUR,
+				Capture:     true,
+				Reference:   Reference,
+				Description: Description,
+				SuccessUrl:  SuccessUrl,
+				FailureUrl:  FailureUrl,
 			},
 			checkForPaymentRequest: func(response *nas.PaymentResponse, err error) {
 				assert.NotNil(t, err)


### PR DESCRIPTION
* Added API key auth to Integrated Platforms Balances (CS2)
* Added patch endpoint for payment instruments (CS2)
* Replace ‘reporting’ scopes with 'reports' on the Reports API (CS2)
* Add new CvConnect APM (CS2)
* Add new Illicado APM (CS2)
* Add new Trustly APM (CS2)
* Rename partner_reason field to partner_error_message in Payments ProcessingData (CS2)