### PR TITLE
googlepay token data signature fix

### DIFF
--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -47,7 +47,7 @@ type (
 	}
 
 	GooglePayTokenData struct {
-		Signature       string `json:"data,omitempty"`
+		Signature       string `json:"signature,omitempty"`
 		ProtocolVersion string `json:"protocolVersion,omitempty"`
 		SignedMessage   string `json:"signedMessage,omitempty"`
 	}


### PR DESCRIPTION
json tag is changed of the Signature field of the GooglePayTokenData struct to fix googlepay