### PR TITLE
Api Updates

### DIFF
--- a/payments/payments.go
+++ b/payments/payments.go
@@ -318,17 +318,18 @@ type (
 	}
 
 	ThreeDsData struct {
-		Downgraded             bool      `json:"downgraded,omitempty"`
-		Enrolled               string    `json:"enrolled,omitempty"`
-		UpgradeReason          string    `json:"upgrade_reason,omitempty"`
-		SignatureValid         string    `json:"signature_valid,omitempty"`
-		AuthenticationResponse string    `json:"authentication_response,omitempty"`
-		Cryptogram             string    `json:"cryptogram,omitempty"`
-		Xid                    string    `json:"xid,omitempty"`
-		Version                string    `json:"version,omitempty"`
-		Exemption              Exemption `json:"exemption,omitempty"`
-		ExemptionApplied       string    `json:"exemption_applied,omitempty"`
-		Challenged             bool      `json:"challenged,omitempty"`
+		Downgraded                 bool      `json:"downgraded,omitempty"`
+		Enrolled                   string    `json:"enrolled,omitempty"`
+		UpgradeReason              string    `json:"upgrade_reason,omitempty"`
+		SignatureValid             string    `json:"signature_valid,omitempty"`
+		AuthenticationResponse     string    `json:"authentication_response,omitempty"`
+		AuthenticationStatusReason string    `json:"authentication_status_reason,omitempty"`
+		Cryptogram                 string    `json:"cryptogram,omitempty"`
+		Xid                        string    `json:"xid,omitempty"`
+		Version                    string    `json:"version,omitempty"`
+		Exemption                  Exemption `json:"exemption,omitempty"`
+		ExemptionApplied           string    `json:"exemption_applied,omitempty"`
+		Challenged                 bool      `json:"challenged,omitempty"`
 	}
 
 	PaymentActionSummary struct {

--- a/test/payments_request_apm_test.go
+++ b/test/payments_request_apm_test.go
@@ -44,7 +44,7 @@ func TestRequestPaymentsAPM(t *testing.T) {
 				assert.Nil(t, response)
 				ckoErr := err.(errors.CheckoutAPIError)
 				assert.Equal(t, http.StatusUnprocessableEntity, ckoErr.StatusCode)
-				assert.Equal(t, "cko_processing_channel_id_invalid", ckoErr.Data.ErrorCodes[0])
+				assert.Equal(t, "apm_service_unavailable", ckoErr.Data.ErrorCodes[0])
 			},
 		},
 		{


### PR DESCRIPTION
### Changes
* Add `authentication_status_reason` to `3DS` object in the GET payment details response

### Related PRs
checkout/checkout-api-reference#906

### API Reference
https://api-reference.checkout.com/#operation/getPaymentDetails