### PR TITLE
Api Updates

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -3,9 +3,11 @@ package errors
 import "fmt"
 
 type ErrorDetails struct {
-	RequestID  string   `json:"request_id,omitempty"`
-	ErrorType  string   `json:"error_type,omitempty"`
-	ErrorCodes []string `json:"error_codes,omitempty"`
+	RequestID  string                 `json:"request_id,omitempty"`
+	ErrorType  string                 `json:"error_type,omitempty"`
+	ErrorCodes []string               `json:"error_codes,omitempty"`
+	Id         string                 `json:"id,omitempty"`
+	Links      map[string]interface{} `json:"_links,omitempty"`
 }
 
 type (

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -318,17 +318,18 @@ type (
 	}
 
 	ThreeDsData struct {
-		Downgraded             bool      `json:"downgraded,omitempty"`
-		Enrolled               string    `json:"enrolled,omitempty"`
-		UpgradeReason          string    `json:"upgrade_reason,omitempty"`
-		SignatureValid         string    `json:"signature_valid,omitempty"`
-		AuthenticationResponse string    `json:"authentication_response,omitempty"`
-		Cryptogram             string    `json:"cryptogram,omitempty"`
-		Xid                    string    `json:"xid,omitempty"`
-		Version                string    `json:"version,omitempty"`
-		Exemption              Exemption `json:"exemption,omitempty"`
-		ExemptionApplied       string    `json:"exemption_applied,omitempty"`
-		Challenged             bool      `json:"challenged,omitempty"`
+		Downgraded                 bool      `json:"downgraded,omitempty"`
+		Enrolled                   string    `json:"enrolled,omitempty"`
+		UpgradeReason              string    `json:"upgrade_reason,omitempty"`
+		SignatureValid             string    `json:"signature_valid,omitempty"`
+		AuthenticationResponse     string    `json:"authentication_response,omitempty"`
+		AuthenticationStatusReason string    `json:"authentication_status_reason,omitempty"`
+		Cryptogram                 string    `json:"cryptogram,omitempty"`
+		Xid                        string    `json:"xid,omitempty"`
+		Version                    string    `json:"version,omitempty"`
+		Exemption                  Exemption `json:"exemption,omitempty"`
+		ExemptionApplied           string    `json:"exemption_applied,omitempty"`
+		Challenged                 bool      `json:"challenged,omitempty"`
 	}
 
 	PaymentActionSummary struct {

--- a/test/payments_request_apm_test.go
+++ b/test/payments_request_apm_test.go
@@ -44,7 +44,7 @@ func TestRequestPaymentsAPM(t *testing.T) {
 				assert.Nil(t, response)
 				ckoErr := err.(errors.CheckoutAPIError)
 				assert.Equal(t, http.StatusUnprocessableEntity, ckoErr.StatusCode)
-				assert.Equal(t, "cko_processing_channel_id_invalid", ckoErr.Data.ErrorCodes[0])
+				assert.Equal(t, "apm_service_unavailable", ckoErr.Data.ErrorCodes[0])
 			},
 		},
 		{


### PR DESCRIPTION
### Changes
* Updates conflict response for onboard sub entity operation to include ID
* Adds `authentication_status_reason` to `3DS` object in the GET payment details response

### Related PRs
checkout/checkout-api-reference#898
checkout/checkout-api-reference#906

### API Reference
https://api-reference.checkout.com/#operation/onboardSubEntity
https://api-reference.checkout.com/#operation/getPaymentDetails