### PR TITLE
Api Updates

### DIFF
--- a/issuing/client_issuing.go
+++ b/issuing/client_issuing.go
@@ -22,6 +22,8 @@ const (
 	controlsPath          = "controls"
 	simulatePath          = "simulate"
 	authorizationsPath    = "authorizations"
+	presentmentsPath      = "presentments"
+	reversalsPath         = "reversals"
 )
 
 type Client struct {
@@ -204,7 +206,10 @@ func (c *Client) GetCardCredentials(
 	}
 
 	var response cards.CardCredentialsResponse
-	url, err := common.BuildQueryPath(common.BuildPath(issuingPath, cardsPath, cardId, credentialsPath), credentialsQuery)
+	url, err := common.BuildQueryPath(
+		common.BuildPath(issuingPath, cardsPath, cardId, credentialsPath),
+		credentialsQuery,
+	)
 	err = c.apiClient.Get(url, auth, &response)
 	if err != nil {
 		return nil, err
@@ -273,7 +278,9 @@ func (c *Client) CreateControl(request controls.CardControlRequest) (*controls.C
 	return &response, nil
 }
 
-func (c *Client) GetCardControls(query controls.CardControlsQuery) (*controls.CardControlsQueryResponse, error) {
+func (c *Client) GetCardControls(
+	query controls.CardControlsQuery,
+) (*controls.CardControlsQueryResponse, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {
 		return nil, err
@@ -343,14 +350,94 @@ func (c *Client) RemoveCardControl(controlId string) (*common.IdResponse, error)
 	return &response, nil
 }
 
-func (c *Client) SimulateAuthorization(request testing.CardAuthorizationRequest) (*testing.CardAuthorizationResponse, error) {
+func (c *Client) SimulateAuthorization(
+	request testing.CardAuthorizationRequest,
+) (*testing.CardAuthorizationResponse, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {
 		return nil, err
 	}
 
 	var response testing.CardAuthorizationResponse
-	err = c.apiClient.Post(common.BuildPath(issuingPath, simulatePath, authorizationsPath), auth, request, &response, nil)
+	err = c.apiClient.Post(
+		common.BuildPath(issuingPath, simulatePath, authorizationsPath),
+		auth,
+		request,
+		&response,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) SimulateIncrement(
+	transactionId string,
+	request testing.CardSimulationRequest,
+) (*testing.CardSimulationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response testing.CardSimulationResponse
+	err = c.apiClient.Post(
+		common.BuildPath(issuingPath, simulatePath, authorizationsPath, transactionId, authorizationsPath),
+		auth,
+		request,
+		&response,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) SimulateClearing(
+	transactionId string,
+	request testing.CardSimulationRequest,
+) (*common.MetadataResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response common.MetadataResponse
+	err = c.apiClient.Post(
+		common.BuildPath(issuingPath, simulatePath, authorizationsPath, transactionId, presentmentsPath),
+		auth,
+		request,
+		&response,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) SimulateReversal(
+	transactionId string,
+	request testing.CardSimulationRequest,
+) (*testing.CardSimulationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response testing.CardSimulationResponse
+	err = c.apiClient.Post(
+		common.BuildPath(issuingPath, simulatePath, authorizationsPath, transactionId, reversalsPath),
+		auth,
+		request,
+		&response,
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/issuing/testing/requests.go
+++ b/issuing/testing/requests.go
@@ -25,4 +25,8 @@ type (
 		Card        CardSimulation        `json:"card,omitempty"`
 		Transaction TransactionSimulation `json:"transaction,omitempty"`
 	}
+
+	CardSimulationRequest struct {
+		Amount int `json:"amount,omitempty"`
+	}
 )

--- a/issuing/testing/responses.go
+++ b/issuing/testing/responses.go
@@ -7,12 +7,18 @@ type TransactionStatus string
 const (
 	Authorized TransactionStatus = "Authorized"
 	Declined   TransactionStatus = "Declined"
+	Reversed   TransactionStatus = "Reversed"
 )
 
 type (
 	CardAuthorizationResponse struct {
 		HttpMetadata common.HttpMetadata
 		Id           string            `json:"id,omitempty"`
+		Status       TransactionStatus `json:"status,omitempty"`
+	}
+
+	CardSimulationResponse struct {
+		HttpMetadata common.HttpMetadata
 		Status       TransactionStatus `json:"status,omitempty"`
 	}
 )

--- a/payments/nas/source.go
+++ b/payments/nas/source.go
@@ -15,15 +15,17 @@ type (
 	}
 
 	ResponseCardSource struct {
-		Type                    payments.SourceType `json:"type,omitempty"`
-		Id                      string              `json:"id,omitempty"`
-		BillingAddress          *common.Address     `json:"billing_address,omitempty"`
-		Phone                   *common.Phone       `json:"phone,omitempty"`
-		ExpiryMonth             int                 `json:"expiry_month,omitempty"`
-		ExpiryYear              int                 `json:"expiry_year,omitempty"`
-		Name                    string              `json:"name,omitempty"`
-		Scheme                  string              `json:"scheme,omitempty"`
+		Type           payments.SourceType `json:"type,omitempty"`
+		Id             string              `json:"id,omitempty"`
+		BillingAddress *common.Address     `json:"billing_address,omitempty"`
+		Phone          *common.Phone       `json:"phone,omitempty"`
+		ExpiryMonth    int                 `json:"expiry_month,omitempty"`
+		ExpiryYear     int                 `json:"expiry_year,omitempty"`
+		Name           string              `json:"name,omitempty"`
+		Scheme         string              `json:"scheme,omitempty"`
+		// Deprecated: This property will be removed in the future, and should not be used. Use LocalSchemes instead.
 		SchemeLocal             string              `json:"scheme_local,omitempty"`
+		LocalSchemes            []string            `json:"local_schemes,omitempty"`
 		Last4                   string              `json:"last4,omitempty"`
 		Fingerprint             string              `json:"fingerprint,omitempty"`
 		Bin                     string              `json:"bin,omitempty"`

--- a/test/issuing_base_test.go
+++ b/test/issuing_base_test.go
@@ -1,12 +1,16 @@
 package test
 
 import (
-	"github.com/checkout/checkout-sdk-go/common"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/checkout/checkout-sdk-go"
+	"github.com/checkout/checkout-sdk-go/common"
 	"github.com/checkout/checkout-sdk-go/configuration"
+	issuingTesting "github.com/checkout/checkout-sdk-go/issuing/testing"
 	"github.com/checkout/checkout-sdk-go/nas"
 
 	cardholders "github.com/checkout/checkout-sdk-go/issuing/cardholders"
@@ -14,38 +18,25 @@ import (
 	controls "github.com/checkout/checkout-sdk-go/issuing/controls"
 )
 
-var issuingClientApi *nas.Api
-var cardholder = cardholders.CardholderRequest{}
-var cardholderResponse *cardholders.CardholderResponse
-var virtualCardResponse *cards.CardResponse
-var virtualCardId string
-var cardControlResponse *controls.CardControlResponse
+var (
+	issuingClientApi *nas.Api
+
+	cardholder          cardholders.CardholderRequest
+	cardholderResponse  *cardholders.CardholderResponse
+	virtualCardResponse *cards.CardResponse
+	cardControlResponse *controls.CardControlResponse
+
+	virtualCardId string
+)
 
 func TestSetupIssuing(t *testing.T) {
 	t.Skip("Avoid creating cards all the time")
-	cardholder = cardholders.CardholderRequest{
-		Type:             cardholders.Individual,
-		Reference:        "X-123456-N11",
-		EntityId:         "ent_mujh2nia2ypezmw5fo2fofk7ka",
-		FirstName:        "John",
-		MiddleName:       "Fitzgerald",
-		LastName:         "Kennedy",
-		Email:            "john.kennedy@myemaildomain.com",
-		PhoneNumber:      Phone(),
-		DateOfBirth:      "1985-05-15",
-		BillingAddress:   Address(),
-		ResidencyAddress: Address(),
-		Document: &cardholders.CardholderDocument{
-			Type:            common.NationalIdentityCard,
-			FrontDocumentId: "file_6lbss42ezvoufcb2beo76rvwly",
-			BackDocumentId:  "file_aaz5pemp6326zbuvevp6qroqu4",
-		},
-	}
 
-	cardholderResponse = cardholderRequest(cardholder)
-	virtualCardResponse = cardRequest(cardholderResponse)
+	cardholderResponse = cardholderRequest(t)
+	virtualCardResponse = cardRequest(t, cardholderResponse)
+	cardControlResponse = cardControlRequest(t, virtualCardId)
+
 	virtualCardId = virtualCardResponse.Id
-	cardControlResponse = cardControlRequest(virtualCardId)
 }
 
 func buildIssuingClientApi() *nas.Api {
@@ -67,12 +58,35 @@ func buildIssuingClientApi() *nas.Api {
 	return issuingClientApi
 }
 
-func cardholderRequest(request cardholders.CardholderRequest) *cardholders.CardholderResponse {
-	response, _ := buildIssuingClientApi().Issuing.CreateCardholder(request)
+func cardholderRequest(t *testing.T) *cardholders.CardholderResponse {
+	request := cardholders.CardholderRequest{
+		Type:             cardholders.Individual,
+		Reference:        "X-123456-N11",
+		EntityId:         "ent_mujh2nia2ypezmw5fo2fofk7ka",
+		FirstName:        "John",
+		MiddleName:       "Fitzgerald",
+		LastName:         "Kennedy",
+		Email:            "john.kennedy@myemaildomain.com",
+		PhoneNumber:      Phone(),
+		DateOfBirth:      "1985-05-15",
+		BillingAddress:   Address(),
+		ResidencyAddress: Address(),
+		Document: &cardholders.CardholderDocument{
+			Type:            common.NationalIdentityCard,
+			FrontDocumentId: "file_6lbss42ezvoufcb2beo76rvwly",
+			BackDocumentId:  "file_aaz5pemp6326zbuvevp6qroqu4",
+		},
+	}
+
+	response, err := buildIssuingClientApi().Issuing.CreateCardholder(request)
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("error creating cardholder - %s", err.Error()))
+	}
+
 	return response
 }
 
-func cardRequest(cardholderResponse *cardholders.CardholderResponse) *cards.CardResponse {
+func cardRequest(t *testing.T, cardholderResponse *cardholders.CardholderResponse) *cards.CardResponse {
 	virtualCard := cards.NewVirtualCardRequest()
 	virtualCard.CardDetailsRequest = cards.CardDetailsRequest{
 		Type:         cards.Virtual,
@@ -88,11 +102,15 @@ func cardRequest(cardholderResponse *cardholders.CardholderResponse) *cards.Card
 	}
 	virtualCard.IsSingleUse = false
 
-	response, _ := buildIssuingClientApi().Issuing.CreateCard(virtualCard)
+	response, err := buildIssuingClientApi().Issuing.CreateCard(virtualCard)
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("error creating card - %s", err.Error()))
+	}
+
 	return response
 }
 
-func cardControlRequest(virtualCardId string) *controls.CardControlResponse {
+func cardControlRequest(t *testing.T, virtualCardId string) *controls.CardControlResponse {
 	velocityCardControl := controls.NewVelocityCardControlRequest()
 	velocityCardControl.ControlType = controls.VelocityLimitType
 	velocityCardControl.Description = "Max spend of 500€ per week for restaurants"
@@ -103,6 +121,32 @@ func cardControlRequest(virtualCardId string) *controls.CardControlResponse {
 			Type: controls.Weekly,
 		},
 	}
-	response, _ := buildIssuingClientApi().Issuing.CreateControl(velocityCardControl)
+	response, err := buildIssuingClientApi().Issuing.CreateControl(velocityCardControl)
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("error creating card control - %s", err.Error()))
+	}
+
+	return response
+}
+
+func cardSimulation(t *testing.T, card cards.CardResponse) *issuingTesting.CardAuthorizationResponse {
+	request := issuingTesting.CardAuthorizationRequest{
+		Card: issuingTesting.CardSimulation{
+			Id:          card.Id,
+			ExpiryMonth: card.ExpiryMonth,
+			ExpiryYear:  card.ExpiryYear,
+		},
+		Transaction: issuingTesting.TransactionSimulation{
+			Type:     issuingTesting.Purchase,
+			Amount:   100,
+			Currency: common.GBP,
+		},
+	}
+
+	response, err := buildIssuingClientApi().Issuing.SimulateAuthorization(request)
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("error authorizing transaction - %s", err.Error()))
+	}
+
 	return response
 }

--- a/test/issuing_card_test.go
+++ b/test/issuing_card_test.go
@@ -38,7 +38,7 @@ func TestCreateCard(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.checker(cardRequest(cardholderResponse), nil)
+			tc.checker(cardRequest(t, cardholderResponse), nil)
 		})
 	}
 }
@@ -218,7 +218,6 @@ func TestActivateCard(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			client.SuspendCard(tc.cardId)
 			tc.checker(client.ActivateCard(tc.cardId))
 		})
 	}

--- a/test/issuing_controls_test.go
+++ b/test/issuing_controls_test.go
@@ -36,7 +36,7 @@ func TestCreateControl(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.checker(cardControlRequest(virtualCardId), nil)
+			tc.checker(cardControlRequest(t, virtualCardId), nil)
 		})
 	}
 }

--- a/test/issuing_testing_test.go
+++ b/test/issuing_testing_test.go
@@ -1,29 +1,19 @@
 package test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/checkout/checkout-sdk-go/common"
+	"github.com/checkout/checkout-sdk-go/errors"
 
 	issuingTesting "github.com/checkout/checkout-sdk-go/issuing/testing"
 )
 
 func TestSimulateAuthorization(t *testing.T) {
 	t.Skip("Avoid creating cards all the time")
-	request := issuingTesting.CardAuthorizationRequest{
-		Card: issuingTesting.CardSimulation{
-			Id:          virtualCardResponse.Id,
-			ExpiryMonth: virtualCardResponse.ExpiryMonth,
-			ExpiryYear:  virtualCardResponse.ExpiryYear,
-		},
-		Transaction: issuingTesting.TransactionSimulation{
-			Type:     issuingTesting.Purchase,
-			Amount:   100,
-			Currency: common.GBP,
-		},
-	}
 
 	cases := []struct {
 		name    string
@@ -31,12 +21,23 @@ func TestSimulateAuthorization(t *testing.T) {
 		checker func(*issuingTesting.CardAuthorizationResponse, error)
 	}{
 		{
-			name:    "when simulate an authorization and this request is correct then should return a response",
-			request: request,
+			name: "when simulate an authorization and this request is correct then should return a response",
+			request: issuingTesting.CardAuthorizationRequest{
+				Card: issuingTesting.CardSimulation{
+					Id:          virtualCardResponse.Id,
+					ExpiryMonth: virtualCardResponse.ExpiryMonth,
+					ExpiryYear:  virtualCardResponse.ExpiryYear,
+				},
+				Transaction: issuingTesting.TransactionSimulation{
+					Type:     issuingTesting.Purchase,
+					Amount:   100,
+					Currency: common.GBP,
+				},
+			},
 			checker: func(response *issuingTesting.CardAuthorizationResponse, err error) {
 				assert.Nil(t, err)
 				assert.NotNil(t, response)
-				assert.Equal(t, 201, response.HttpMetadata.StatusCode)
+				assert.Equal(t, http.StatusCreated, response.HttpMetadata.StatusCode)
 				assert.Equal(t, issuingTesting.Declined, response.Status)
 			},
 		},
@@ -47,6 +48,137 @@ func TestSimulateAuthorization(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.checker(client.SimulateAuthorization(tc.request))
+		})
+	}
+}
+
+func TestSimulateIncrement(t *testing.T) {
+	t.Skip("Avoid creating cards all the time")
+
+	transactionId := cardSimulation(t, *virtualCardResponse)
+
+	cases := []struct {
+		name          string
+		transactionId string
+		request       issuingTesting.CardSimulationRequest
+		checker       func(*issuingTesting.CardSimulationResponse, error)
+	}{
+		{
+			name:          "when simulating an increment authorization with valid request then return response",
+			transactionId: transactionId.Id,
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *issuingTesting.CardSimulationResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusCreated, response.HttpMetadata.StatusCode)
+				assert.Equal(t, issuingTesting.Authorized, response.Status)
+			},
+		},
+		{
+			name:          "when simulating an increment authorization with invalid transactionId then return error",
+			transactionId: "not_found",
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *issuingTesting.CardSimulationResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIssuingClientApi().Issuing
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.SimulateIncrement(tc.transactionId, tc.request))
+		})
+	}
+}
+
+func TestSimulateClearance(t *testing.T) {
+	t.Skip("Avoid creating cards all the time")
+
+	transactionId := cardSimulation(t, *virtualCardResponse)
+
+	cases := []struct {
+		name          string
+		transactionId string
+		request       issuingTesting.CardSimulationRequest
+		checker       func(*common.MetadataResponse, error)
+	}{
+		{
+			name:          "when simulating a clearance authorization with valid request then return response",
+			transactionId: transactionId.Id,
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *common.MetadataResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusAccepted, response.HttpMetadata.StatusCode)
+			},
+		},
+		{
+			name:          "when simulating a clearance authorization with invalid transactionId then return error",
+			transactionId: "not_found",
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *common.MetadataResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIssuingClientApi().Issuing
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.SimulateClearing(tc.transactionId, tc.request))
+		})
+	}
+}
+
+func TestSimulateReversal(t *testing.T) {
+	t.Skip("Avoid creating cards all the time")
+
+	transactionId := cardSimulation(t, *virtualCardResponse)
+
+	cases := []struct {
+		name          string
+		transactionId string
+		request       issuingTesting.CardSimulationRequest
+		checker       func(*issuingTesting.CardSimulationResponse, error)
+	}{
+		{
+			name:          "when simulating a reversal authorization with valid request then return response",
+			transactionId: transactionId.Id,
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *issuingTesting.CardSimulationResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusCreated, response.HttpMetadata.StatusCode)
+				assert.Equal(t, issuingTesting.Reversed, response.Status)
+			},
+		},
+		{
+			name:          "when simulating a reversal authorization with invalid transactionId then return error",
+			transactionId: "not_found",
+			request:       issuingTesting.CardSimulationRequest{Amount: 100},
+			checker: func(response *issuingTesting.CardSimulationResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIssuingClientApi().Issuing
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.SimulateReversal(tc.transactionId, tc.request))
 		})
 	}
 }


### PR DESCRIPTION
### Changes
* Adds `LocalSchemes` and deprecates `SchemeLocal` in `ResponseCardSource` (CS2)
* Adds support for `SimulateIncrement` for `Card Testing` [Issuing] (CS2)
* Adds support for `SimulateClearing` for `Card Testing` [Issuing] (CS2)
* Adds support for `SimulateReversal` for `Card Testing` [Issuing] (CS2)

### Related PRs
cko-web/checkout-api-reference#926
cko-web/checkout-api-reference#920
cko-web/checkout-api-reference#936

API Reference
https://api-reference.checkout.com/#operation/getPaymentDetails
https://api-reference.checkout.com/#tag/Card-testing