### PR TITLE
Fix json tags in metadata package

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -30,7 +30,7 @@ type PayoutsTransactionsType string
 const (
 	NotSupported PayoutsTransactionsType = "not_supported"
 	Standard     PayoutsTransactionsType = "standard"
-	FastFounds   PayoutsTransactionsType = "fast_founds"
+	FastFunds    PayoutsTransactionsType = "fast_funds"
 	Unknown      PayoutsTransactionsType = "unknown"
 )
 
@@ -63,6 +63,6 @@ type (
 		IssuerCountryName string               `json:"issuer_country_name,omitempty"`
 		ProductId         string               `json:"product_id,omitempty"`
 		ProductType       string               `json:"product_type,omitempty"`
-		CardPayouts       *CardMetadataPayouts `json:"card-payouts,omitempty"`
+		CardPayouts       *CardMetadataPayouts `json:"card_payouts,omitempty"`
 	}
 )


### PR DESCRIPTION
Fixes a typo in `FastFunds` const and aligns the `CardPayouts` json tag with the actual payload received from the metadata endpoint:

![image](https://github.com/checkout/checkout-sdk-go/assets/75726250/7762e096-4598-4978-91c9-4c1b6c4d0af4)
