### PR TITLE
Add CurrencyAccountId to AccountBalance struct

### DIFF
--- a/balances/balances.go
+++ b/balances/balances.go
@@ -22,9 +22,10 @@ type (
 	}
 
 	AccountBalance struct {
-		Descriptor      string   `json:"descriptor,omitempty"`
-		HoldingCurrency string   `json:"holding_currency,omitempty"`
-		Balances        Balances `json:"balances,omitempty"`
+		Descriptor        string   `json:"descriptor,omitempty"`
+		CurrencyAccountId string   `json:"currency_account_id,omitempty"`
+		HoldingCurrency   string   `json:"holding_currency,omitempty"`
+		Balances          Balances `json:"balances,omitempty"`
 	}
 
 	QueryResponse struct {


### PR DESCRIPTION
## Problem

The `GET /balances/:id` API returns a `currency_account_id` field when this API is requested with the query param `?withCurrencyAccountId=true`. 

The go sdk seems to be missing this field in the `AccountBalance` struct.

#### Example HTTP Request & Response</summary>
```
GET /balances/ent_abc123?withCurrencyAccountId=true HTTP/1.1
Accept: application/json
Authorization: Bearer sk_<redacted>
Host: balances.checkout.com
 
HTTP/1.1 200 OK 
{
    "data": [
        {
            "currency_account_id": "ca_def456",
            "descriptor": "Acme, Inc. - USD",
            "holding_currency": "USD",
            "balances": {
                "available": 123456,
                "collateral": 0,
                "payable": 0,
                "pending": 0
            }
        }
    ],
    "_links": {
        "self": {
            "href": "https://balances.checkout.com/balances/ent_abc123?withCurrencyAccountId=true"
        }
    }
}
```

## Solution

Add the missing field to the `AccountBalance` struct.