### PR TITLE
Add WithCurrencyAccountId to QueryFilter struct

### DIFF
--- a/balances/balances.go
+++ b/balances/balances.go
@@ -8,7 +8,8 @@ const (
 
 type (
 	QueryFilter struct {
-		Query string `url:"query,omitempty"`
+		Query                 string `url:"query,omitempty"`
+		WithCurrencyAccountId bool   `url:"withCurrencyAccountId,omitempty"`
 	}
 )
 


### PR DESCRIPTION
As per [documentation](https://api-reference.checkout.com/#operation/getEntityBalances), the `/balances` endpoint currently supports following query parameters: 

**Query** (e.g. "query=currency:USD") which allows filtering accounts by a provided currency. 
**WithCurrencyAccountId** (e.g. "withCurrencyAccountId=true") which can be used to include the account id in the response.  

This PR adds `WithCurrencyAccountId` field to the QueryFilter struct to allow using WithCurrencyAccountId in the Blances request.