### PR TITLE
Remove omitempty tag from AmountAllocations's amount field

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -247,7 +247,7 @@ type (
 
 	AmountAllocations struct {
 		Id         string      `json:"id,omitempty"`
-		Amount     int64       `json:"amount,omitempty"`
+		Amount     int64       `json:"amount"`
 		Reference  string      `json:"reference,omitempty"`
 		Commission *Commission `json:"commission,omitempty"`
 	}


### PR DESCRIPTION
# Problem: 
I got the following error when I tried to send a Credit Card verification request with a 0 amount.
```
{
    "request_id": "some_id",
    "error_type": "request_invalid",
    "error_codes": [
        "sub_entity_amount_required"
    ]
}
```
That happened because the `amount_allocations`'s `amount` field was 0, so the `json.Marshal(...)` removed it from the result JSON object.

# Solution:
I recommend removing the `omitempty` tag from this field because the amount should always be present.