### PR TITLE
removed-omitempty-from-store-for-future-use

### DIFF
--- a/payments/abc/sources/sources.go
+++ b/payments/abc/sources/sources.go
@@ -14,7 +14,7 @@ type (
 		Name              string              `json:"name,omitempty"`
 		Cvv               string              `json:"cvv,omitempty"`
 		Stored            bool                `json:"stored,omitempty"`
-		StoreForFutureUse bool                `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool                `json:"store_for_future_use"`
 		BillingAddress    *common.Address     `json:"billing_address,omitempty"`
 		Phone             *common.Phone       `json:"phone,omitempty"`
 	}
@@ -24,7 +24,7 @@ type (
 		Id                string              `json:"id,omitempty"`
 		Cvv               string              `json:"cvv,omitempty"`
 		Stored            *bool               `json:"stored,omitempty"`
-		StoreForFutureUse *bool               `json:"storeForFutureUse,omitempty"`
+		StoreForFutureUse *bool               `json:"storeForFutureUse"`
 	}
 
 	requestCustomerSource struct {
@@ -38,7 +38,7 @@ type (
 		BillingAddress    *common.Address     `json:"billing_address,omitempty"`
 		Phone             *common.Phone       `json:"phone,omitempty"`
 		Stored            *bool               `json:"stored,omitempty"`
-		StoreForFutureUse bool                `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool                `json:"store_for_future_use"`
 	}
 
 	requestNetworkTokenSource struct {
@@ -64,7 +64,7 @@ type (
 		Name              string              `json:"name,omitempty"`
 		Cvv               string              `json:"cvv,omitempty"`
 		Stored            bool                `json:"stored"`
-		StoreForFutureUse bool                `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool                `json:"store_for_future_use"`
 		BillingAddress    *common.Address     `json:"billing_address,omitempty"`
 		Phone             *common.Phone       `json:"phone,omitempty"`
 	}

--- a/payments/nas/sources/sources.go
+++ b/payments/nas/sources/sources.go
@@ -14,7 +14,7 @@ type (
 		Name              string              `json:"name,omitempty"`
 		Cvv               string              `json:"cvv,omitempty"`
 		Stored            bool                `json:"stored"`
-		StoreForFutureUse bool                `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool                `json:"store_for_future_use"`
 		BillingAddress    *common.Address     `json:"billing_address,omitempty"`
 		Phone             *common.Phone       `json:"phone,omitempty"`
 	}
@@ -25,7 +25,7 @@ type (
 		Cvv               string              `json:"cvv,omitempty"`
 		PaymentMethod     string              `json:"payment_method,omitempty"`
 		Stored            *bool               `json:"stored,omitempty"`
-		StoreForFutureUse *bool               `json:"storeForFutureUse,omitempty"`
+		StoreForFutureUse *bool               `json:"storeForFutureUse"`
 	}
 
 	requestTokenSource struct {
@@ -34,7 +34,7 @@ type (
 		BillingAddress    *common.Address     `json:"billing_address,omitempty"`
 		Phone             *common.Phone       `json:"phone,omitempty"`
 		Stored            *bool               `json:"stored,omitempty"`
-		StoreForFutureUse bool                `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool                `json:"store_for_future_use"`
 	}
 
 	requestProviderTokenSource struct {

--- a/sessions/sources/session_sources.go
+++ b/sessions/sources/session_sources.go
@@ -46,7 +46,7 @@ type (
 		ExpiryYear        int    `json:"expiry_year,omitempty"`
 		Name              string `json:"name,omitempty"`
 		Stored            bool   `json:"stored,omitempty"`
-		StoreForFutureUse bool   `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool   `json:"store_for_future_use"`
 	}
 
 	sessionIdSource struct {
@@ -57,7 +57,7 @@ type (
 	sessionTokenSource struct {
 		SessionSourceInfo
 		Token             string `json:"token,omitempty"`
-		StoreForFutureUse bool   `json:"store_for_future_use,omitempty"`
+		StoreForFutureUse bool   `json:"store_for_future_use"`
 	}
 
 	sessionNetworkTokenSource struct {


### PR DESCRIPTION
When `StoreForFutureUse` is sent as `false`, because of omitempty here in structs causes the variable to disappear from the request and causes an issue if ur not sending true.

Reference Checkout doc: "To prevent card details from being stored, you must explicitly set "store_for_future_use": false in the payment request."
"To provide a seamless experience in these scenarios, store_for_future_use is set to true by default."
