### PR TITLE
Add resolved_reason mapping to dispute_summary

### DIFF
--- a/disputes/disputes.go
+++ b/disputes/disputes.go
@@ -128,9 +128,10 @@ type (
 		LastUpdate         *time.Time      `json:"last_update,omitempty"`
 
 		// Not available on Previous
-		EntityId    string `json:"entity_id,omitempty"`
-		SubEntityId string `json:"sub_entity_id,omitempty"`
-		PaymentMcc  string `json:"payment_mcc,omitempty"`
+		EntityId       string                `json:"entity_id,omitempty"`
+		SubEntityId    string                `json:"sub_entity_id,omitempty"`
+		PaymentMcc     string                `json:"payment_mcc,omitempty"`
+		ResolvedReason DisputeResolvedReason `json:"resolved_reason,omitempty"`
 	}
 )
 


### PR DESCRIPTION
Hey folks 👋 

This PR adds a field `ResolvedReason` on `DisputeSummary` struct. This field returned in the API call - [see docs](https://api-reference.checkout.com/#operation/getDisputes!c=200&path=data/resolved_reason&t=response), but is not handled in the SDK.