### PR TITLE
Allow Amount to be zero in sessions.PaymentSessionsRequest

### DIFF
--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -42,7 +42,7 @@ type (
 	}
 
 	PaymentSessionsRequest struct {
-		Amount                     int64                                `json:"amount,omitempty"`
+		Amount                     int64                                `json:"amount"`
 		Currency                   common.Currency                      `json:"currency,omitempty"`
 		PaymentType                payments.PaymentType                 `json:"payment_type,omitempty"`
 		Billing                    *payments.BillingInformation         `json:"billing,omitempty"`


### PR DESCRIPTION
Hi folks!  This change allows the `Amount` field to be zero so we can use `PaymentSessionsRequest` objects for verifications in `Flow`.  Previously, doing something like the following (hand-wavey code) would result in `amount_required` errors from the Checkout API.

```golang
import (
        checkoutCommon "github.com/checkout/checkout-sdk-go/common"
	"github.com/checkout/checkout-sdk-go/configuration"
	checkoutErrors "github.com/checkout/checkout-sdk-go/errors"
	"github.com/checkout/checkout-sdk-go/nas"
	checkoutPayments "github.com/checkout/checkout-sdk-go/payments"
	paymentsessions "github.com/checkout/checkout-sdk-go/payments/sessions"
)

resp, err := c.client.PaymentSessions.RequestPaymentSessions(paymentsessions.PaymentSessionsRequest{
	Amount:      int64(0), // Amount of zero indicates a card verification
	Currency:    "USD",
	PaymentType: "Regular",
	Billing: &checkoutPayments.BillingInformation{
		Address: &checkoutCommon.Address{
			AddressLine1: "100 main street",
			AddressLine2: "apt 100",
			City:         "Philadelphia",
			State:        "PA",
			Zip:          "19000",
			Country:      "US",
		},
		Phone: &checkoutCommon.Phone{
			CountryCode: "+1",
			Number:      "5558675309",
		},
	},
	BillingDescriptor: &checkoutPayments.BillingDescriptor{
		Name:      "Test billing descriptor",
		City:      "Philly",
		Reference: uuid.NewString(),
	},
	Reference:   uuid.NewString(),
	Description: "Test verification",
	Customer: &checkoutCommon.CustomerRequest{
		Email: "foo@example.com",
		Name:  "Test Testerson",
		Phone: &checkoutCommon.Phone{
			CountryCode: "+1",
			Number:      "5558675309",
		},
		Default: false,
	},
	ProcessingChannelId: processingChannel,
	ExpiresOn:           &sessionDuration,
	PaymentMethodConfiguration: &checkoutPayments.PaymentMethodConfiguration{
		Card: &checkoutPayments.Card{},
	},
	DisplayName: "Test Brand",
	SuccessUrl:  "https://example.com/payments/success",
	FailureUrl:  "https://example.com/payments/failure",
	Metadata:    nil,
	Locale:      "en-GB",
	Sender:      nil,
	Capture:     true,
})
```

if you had tried to create a payment session request object with an Amount of zero, indicating you're doing a verification, the amount field would be excluded from the request payload going over the wire.  This resulted in the CreatePaymentSession API call in kicking back a `amount_required` error since the Checkout API didn't receive the `amount` field.