### PR TITLE
Add signature handling for dLocal API requests

### DIFF
--- a/test/forward_test.go
+++ b/test/forward_test.go
@@ -11,6 +11,11 @@ func getForwardRequestIdSource() forward.ForwardRequest {
 	IdSource := forward.NewIdSource()
 	IdSource.Id = "src_v5rgkf3gdtpuzjqesyxmyodnya"
 
+	DlocalSignature := forward.NewDlocalSignature()
+	DlocalSignature.DlocalParameters = forward.DlocalParameters{
+		SecretKey: "9f439fe1a9f96e67b047d3c1a28c33a2e",
+	}
+
 	request := forward.ForwardRequest{
 		Source: IdSource,
 		DestinationRequest: &forward.DestinationRequest{
@@ -23,7 +28,8 @@ func getForwardRequestIdSource() forward.ForwardRequest {
 					"Content-Type":    "application/json",
 				},
 			},
-			Body: `{\"amount\": 1000, \"currency\": \"USD\", \"reference\": \"some_reference\", \"source\": {\"type\": \"card\", \"number\": \"{{card_number}}\", \"expiry_month\": \"{{card_expiry_month}}\", \"expiry_year\": \"{{card_expiry_year_yyyy}}\", \"name\": \"Ali Farid\"}, \"payment_type\": \"Regular\", \"authorization_type\": \"Final\", \"capture\": true, \"processing_channel_id\": \"pc_xxxxxxxxxxx\", \"risk\": {\"enabled\": false}, \"merchant_initiated\": true}`,
+			Body:      `{\"amount\": 1000, \"currency\": \"USD\", \"reference\": \"some_reference\", \"source\": {\"type\": \"card\", \"number\": \"{{card_number}}\", \"expiry_month\": \"{{card_expiry_month}}\", \"expiry_year\": \"{{card_expiry_year_yyyy}}\", \"name\": \"Ali Farid\"}, \"payment_type\": \"Regular\", \"authorization_type\": \"Final\", \"capture\": true, \"processing_channel_id\": \"pc_xxxxxxxxxxx\", \"risk\": {\"enabled\": false}, \"merchant_initiated\": true}`,
+			Signature: DlocalSignature,
 		},
 		Reference:           "ORD-5023-4E89",
 		ProcessingChannelId: "pc_azsiyswl7bwe2ynjzujy7lcjca",


### PR DESCRIPTION
This pull request introduces support for adding signatures to forwarded HTTP requests, specifically integrating dLocal's signature mechanism. It includes updates to the `forward` package to define new types and methods for signatures and modifies the `DestinationRequest` struct to support optional signature configurations. Additionally, corresponding test cases are added to validate the new functionality.

### Enhancements to Signature Support:

* **New `SignatureType` and `AbstractSignature` interface**: Added `SignatureType` and `AbstractSignature` to represent and manage different signature mechanisms. Defined `dlocalSignature` as an implementation of `AbstractSignature`. (`forward/forward.go`, [[1]](diffhunk://#diff-a15224f7ee11d36c62efdd6852b91db889f42e28038dbeccf7118e393c845afbR25-R36) [[2]](diffhunk://#diff-a15224f7ee11d36c62efdd6852b91db889f42e28038dbeccf7118e393c845afbR70-R84)
* **`DestinationRequest` struct updates**: Introduced a new `Signature` field in `DestinationRequest` to optionally include signature configurations in forwarded requests. (`forward/forward.go`, [forward/forward.goL75-R114](diffhunk://#diff-a15224f7ee11d36c62efdd6852b91db889f42e28038dbeccf7118e393c845afbL75-R114))
* **Factory method for dLocal signature**: Added `NewDlocalSignature` function to create instances of `dlocalSignature` with predefined type. (`forward/forward.go`, [forward/forward.goR194-R208](diffhunk://#diff-a15224f7ee11d36c62efdd6852b91db889f42e28038dbeccf7118e393c845afbR194-R208))

### Testing Additions:

* **Test case updates**: Modified `getForwardRequestIdSource` test to include a `DlocalSignature` instance, ensuring the signature functionality is properly validated. (`test/forward_test.go`, [[1]](diffhunk://#diff-dba80d67a6d1e7b64d2b1743d74695a2a8764b0088399e5d626e507e55ad1893R14-R18) [[2]](diffhunk://#diff-dba80d67a6d1e7b64d2b1743d74695a2a8764b0088399e5d626e507e55ad1893R32)