### PR TITLE
Add missing 'forward' scope to oauth_scopes

### DIFF
--- a/configuration/oauth_scopes.go
+++ b/configuration/oauth_scopes.go
@@ -49,4 +49,5 @@ const (
 	IssuingControlsRead         = "issuing:controls-read"
 	IssuingControlsWrite        = "issuing:controls-write"
 	PaymentContexts             = "Payment Contexts"
+	Forward                     = "forward"
 )


### PR DESCRIPTION
This pull request includes a small change to the `configuration/oauth_scopes.go` file. The change adds a new constant, `Forward`, to the list of OAuth scopes.