### PR TITLE
Release 1.8.1 - APIShortDate type for yyyy-MM-dd date formats

### DIFF
--- a/client/version.go
+++ b/client/version.go
@@ -1,3 +1,3 @@
 package client
 
-const SDK_VERSION = "1.8.0"
+const SDK_VERSION = "1.8.1"


### PR DESCRIPTION
This release introduces a new custom date type, APIShortDate, to enforce strict handling of API date fields in the yyyy-MM-dd format. The main changes include implementing this type, updating relevant data structures to use it, and adding comprehensive tests to ensure correct parsing and formatting.

API Date Handling Improvements:

    Added a new APIShortDate type in common/apishortdate.go that supports only the yyyy-MM-dd format, with custom JSON marshal/unmarshal logic to reject other date/time formats.
    Updated the InstrumentData struct's DateOfSignature field in instruments/nas/instuments.go to use *common.APIShortDate instead of *time.Time, ensuring only valid short dates are accepted.

Test Coverage Enhancements:

    Added a new test suite in test/apishortdate_test.go covering valid/invalid formats, round-trip marshalling, and edge cases for APIShortDate.
    Updated test helpers and integration tests to use and validate the new APIShortDate type, including changes in instruments/nas/client_test.go and test/instruments_test.go. [[1]](https://github.com/checkout/checkout-sdk-go/pull/193/files#diff-c2a686ec6e5a7e11e580c410ac46e4e01e1dc5d2d740ed07038918857e515828L240-R242) [[2]](https://github.com/checkout/checkout-sdk-go/pull/193/files#diff-c2a686ec6e5a7e11e580c410ac46e4e01e1dc5d2d740ed07038918857e515828L249-R251) [[3]](https://github.com/checkout/checkout-sdk-go/pull/193/files#diff-71038e88345d2465934d8e221abf92d63d08a58bee0f6b7a8d93dc119c9302ddR220-R231)

Codebase Cleanup:

    Removed unnecessary imports of time in instruments/nas/instuments.go since date handling is now abstracted by APIShortDate.
    Minor import reordering for clarity in test files.