### PR TITLE
docs: update README for v2.0.0 with /v2 module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![build-status](https://github.com/checkout/checkout-sdk-go/workflows/build-release/badge.svg)](https://github.com/checkout/checkout-sdk-go/actions/workflows/build-release.yml)
 [![GitHub release](https://img.shields.io/github/release/checkout/checkout-sdk-go.svg)](https://github.com/checkout/checkout-sdk-go/releases/)
-[![Go Reference](https://pkg.go.dev/badge/github.com/checkout/checkout-sdk-go.svg)](https://pkg.go.dev/github.com/checkout/checkout-sdk-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/checkout/checkout-sdk-go/v2.svg)](https://pkg.go.dev/github.com/checkout/checkout-sdk-go/v2)
 
 [![GitHub license](https://img.shields.io/github/license/checkout/checkout-sdk-go.svg)](https://github.com/checkout/checkout-sdk-go/blob/master/LICENSE.md)
 
@@ -20,10 +20,18 @@
 ### Module installer
 Make sure your project is using Go Modules:
 ```sh
-go get github.com/checkout/checkout-sdk-go@{version}
+# For v2.x (current)
+go get github.com/checkout/checkout-sdk-go/v2@v2.0.0
+
+# For v1.x (legacy)
+go get github.com/checkout/checkout-sdk-go@v1.9.0
 ```
 Then import the library into your code:
 ```sh
+# For v2.x
+import "github.com/checkout/checkout-sdk-go/v2"
+
+# For v1.x
 import "github.com/checkout/checkout-sdk-go"
 ```
 
@@ -63,8 +71,8 @@ Default keys client instantiation can be done as follows:
 
 ```go
 import (
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 api, err := checkout.Builder().
@@ -81,8 +89,8 @@ The SDK supports client credentials OAuth, when initialized as follows:
 
 ```go
 import (
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 api, err := checkout.Builder().
@@ -100,8 +108,8 @@ If your pair of keys matches the previous system type, this is how the SDK shoul
 
 ```go
 import (
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 api, err := checkout.Builder().
@@ -116,8 +124,8 @@ Then just get any client, and start making requests:
 
 ```go
 import (
-    "github.com/checkout/checkout-sdk-go/payments"
-    "github.com/checkout/checkout-sdk-go/payments/nas"
+    "github.com/checkout/checkout-sdk-go/v2/payments"
+    "github.com/checkout/checkout-sdk-go/v2/payments/nas"
 )
 
 request := nas.PaymentRequest{}
@@ -136,8 +144,8 @@ Go SDK supports your own configuration for `http client` using `http.Client` fro
 import (
     "net/http"
     
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 httpClient := http.Client{
@@ -161,8 +169,8 @@ The SDK supports custom Log provider. You can provide your log configuration via
 import (
     "log"	
 	
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 logger := log.New(os.Stderr, "checkout-sdk-go - ", log.LstdFlags)
@@ -181,8 +189,8 @@ In case that you want to use an integrator or mock server, you can specify your 
 
 ```go
 import (
-    "github.com/checkout/checkout-sdk-go"
-    "github.com/checkout/checkout-sdk-go/configuration"
+    "github.com/checkout/checkout-sdk-go/v2"
+    "github.com/checkout/checkout-sdk-go/v2/configuration"
 )
 
 environment := configuration.NewEnvironment(


### PR DESCRIPTION
- Updated pkg.go.dev badge to point to /v2
- Updated installation instructions to show v2.x vs v1.x
- Updated all code examples to use /v2 imports
- Added clear migration guide in installation section