### PR TITLE
Add missed properties to SubmitPaymentSessionRequest 

### DIFF
--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -155,6 +155,7 @@ type (
 		ThreeDsRequest *payments.ThreeDsRequestFlowHostedLinks `json:"3ds,omitempty"`
 		IpAddress      string                                  `json:"ip_address,omitempty"`
 		PaymentType    payments.PaymentType                    `json:"payment_type,omitempty"`
+		Capture        bool                                    `json:"capture,omitempty"`
 		Metadata       map[string]interface{}                  `json:"metadata,omitempty"`
 	}
 

--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -155,6 +155,7 @@ type (
 		ThreeDsRequest *payments.ThreeDsRequestFlowHostedLinks `json:"3ds,omitempty"`
 		IpAddress      string                                  `json:"ip_address,omitempty"`
 		PaymentType    payments.PaymentType                    `json:"payment_type,omitempty"`
+		Metadata       map[string]interface{}                  `json:"metadata,omitempty"`
 	}
 
 	// Response structures for payment session submit/complete endpoints

--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -155,6 +155,7 @@ type (
 		ThreeDsRequest *payments.ThreeDsRequestFlowHostedLinks `json:"3ds,omitempty"`
 		IpAddress      string                                  `json:"ip_address,omitempty"`
 		PaymentType    payments.PaymentType                    `json:"payment_type,omitempty"`
+		Capture        bool                                    `json:"capture"`
 		Metadata       map[string]interface{}                  `json:"metadata,omitempty"`
 	}
 

--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -148,15 +148,28 @@ type (
 	}
 
 	SubmitPaymentSessionRequest struct {
-		SessionData    string                                  `json:"session_data"`
-		Amount         int64                                   `json:"amount,omitempty"`
-		Reference      string                                  `json:"reference,omitempty"`
-		Items          []payments.Product                      `json:"items,omitempty"`
-		ThreeDsRequest *payments.ThreeDsRequestFlowHostedLinks `json:"3ds,omitempty"`
-		IpAddress      string                                  `json:"ip_address,omitempty"`
-		PaymentType    payments.PaymentType                    `json:"payment_type,omitempty"`
-		Capture        bool                                    `json:"capture,omitempty"`
-		Metadata       map[string]interface{}                  `json:"metadata,omitempty"`
+		SessionData                string                                   `json:"session_data"`
+		Amount                     int64                                    `json:"amount,omitempty"`
+		Currency                   common.Currency                          `json:"currency,omitempty"`
+		Billing                    *payments.BillingInformation             `json:"billing,omitempty"`
+		SuccessUrl                 string                                   `json:"success_url,omitempty"`
+		FailureUrl                 string                                   `json:"failure_url,omitempty"`
+		BillingDescriptor          *payments.BillingDescriptor              `json:"billing_descriptor,omitempty"`
+		Customer                   *common.CustomerRequest                  `json:"customer,omitempty"`
+		Shipping                   *payments.ShippingDetailsFlowHostedLinks `json:"shipping,omitempty"`
+		Reference                  string                                   `json:"reference,omitempty"`
+		Items                      []payments.Product                       `json:"items,omitempty"`
+		ThreeDsRequest             *payments.ThreeDsRequestFlowHostedLinks  `json:"3ds,omitempty"`
+		IpAddress                  string                                   `json:"ip_address,omitempty"`
+		ProcessingChannelId        string                                   `json:"processing_channel_id,omitempty"`
+		PaymentMethodConfiguration *payments.PaymentMethodConfiguration     `json:"payment_method_configuration,omitempty"`
+		PaymentType                payments.PaymentType                     `json:"payment_type,omitempty"`
+		Recipient                  *payments.PaymentRecipient               `json:"recipient,omitempty"`
+		Instruction                *payments.PaymentInstruction             `json:"instruction,omitempty"`
+		Sender                     *nas.Sender                              `json:"sender,omitempty"`
+		Capture                    bool                                     `json:"capture,omitempty"`
+		CaptureOn                  *time.Time                               `json:"capture_on,omitempty"`
+		Metadata                   map[string]interface{}                   `json:"metadata,omitempty"`
 	}
 
 	// Response structures for payment session submit/complete endpoints


### PR DESCRIPTION
## Add missed properties to SubmitPaymentSessionRequest 

This PR extends `SubmitPaymentSessionRequest` to include more optional fields which supposed to be supported by SDK according to the official API documentation.

API reference: https://api-reference.checkout.com/#operation/SubmitPaymentSession