### PR TITLE
Add additional fields to PayoutRequest

### DIFF
--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -76,6 +76,18 @@ type (
 		Reference string `json:"reference,omitempty"`
 	}
 
+	CardPayoutItem struct {
+		Type    payments.ItemType    `json:"type,omitempty"`
+		SubType payments.ItemSubType `json:"sub_type,omitempty"`
+	}
+
+	CardPayoutProcessing struct {
+		AffiliateId     string         `json:"affiliate_id,omitempty"`
+		AffiliateUrl    string         `json:"affiliate_url,omitempty"`
+		ProcessingSpeed string         `json:"processing_speed,omitempty"`
+		PurchaseCountry common.Country `json:"purchase_country,omitempty"`
+	}
+
 	PaymentInstruction struct {
 		Purpose           PaymentPurposeType        `json:"purpose,omitempty"`
 		ChargeBearer      string                    `json:"charge_bearer,omitempty"`
@@ -158,16 +170,20 @@ type (
 	}
 
 	PayoutRequest struct {
-		Source              sources.PayoutSource     `json:"source,omitempty"`
-		Destination         payments.Destination     `json:"destination,omitempty"`
-		Amount              int64                    `json:"amount,omitempty"`
-		Currency            common.Currency          `json:"currency,omitempty"`
-		Reference           string                   `json:"reference,omitempty"`
-		BillingDescriptor   *PayoutBillingDescriptor `json:"billing_descriptor,omitempty"`
-		Sender              Sender                   `json:"sender,omitempty"`
-		Instruction         *PaymentInstruction      `json:"instruction,omitempty"`
-		ProcessingChannelId string                   `json:"processing_channel_id,omitempty"`
-		Metadata            map[string]interface{}   `json:"metadata,omitempty"`
+		Source              sources.PayoutSource      `json:"source,omitempty"`
+		Destination         payments.Destination      `json:"destination,omitempty"`
+		Amount              int64                     `json:"amount,omitempty"`
+		Currency            common.Currency           `json:"currency,omitempty"`
+		Reference           string                    `json:"reference,omitempty"`
+		BillingDescriptor   *PayoutBillingDescriptor  `json:"billing_descriptor,omitempty"`
+		Sender              Sender                    `json:"sender,omitempty"`
+		Instruction         *PaymentInstruction       `json:"instruction,omitempty"`
+		ProcessingChannelId string                    `json:"processing_channel_id,omitempty"`
+		PreviousPaymentId   string                    `json:"previous_payment_id,omitempty"`
+		Items               []CardPayoutItem          `json:"items,omitempty"`
+		Segment             *payments.PaymentSegment  `json:"segment,omitempty"`
+		Processing          *CardPayoutProcessing     `json:"processing,omitempty"`
+		Metadata            map[string]interface{}    `json:"metadata,omitempty"`
 	}
 
 	IncrementAuthorizationRequest struct {


### PR DESCRIPTION
Hello from Coinbase 👋

We use your SDK to integrate with the Checkout API to process payouts. However, we noticed that the SDK is lacking some fields that the [API documentation](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout) shows as available for card payouts. Namely:
* `items`
* `previous_payment_id`
* `segment`
* `processing`

This PR proposes to reflect these fields via the SDK by adding them to the `PayoutRequest` struct.

**_Note:_** I noticed that while both payins and payouts support some of the same fields (`items`, `processing`), the allowed contents within those fields differ between payins and payouts. Therefore I propose the creation of two new structs: `CardPayoutItem` and `CardPayoutProcessing` which accurately reflect the fields that are specific to payouts. Please let me know if these structs belong in a different package.

The `items` field is especially crucial for Coinbase to allow us to accurately identify crypto-related card payouts.