### PR TITLE
Search payments endpoint implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 .idea
 *.DS_Store*
+.cursor/rules/*.mdc
+.cursor/skills/endpoint-review-auto/*.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug OAuth Test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/test",
+            "args": [
+                "-test.run",
+                "TestOauthCheckoutSdks",
+                "-test.v"
+            ],
+            "env": {
+                "CHECKOUT_DEFAULT_OAUTH_CLIENT_ID": "${env:CHECKOUT_DEFAULT_OAUTH_CLIENT_ID}",
+                "CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET": "${env:CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET}"
+            },
+            "showLog": true
+        },
+        {
+            "name": "Debug OAuth Test (Mock)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/test",
+            "args": [
+                "-test.run",
+                "TestOauthCheckoutSdks",
+                "-test.v"
+            ],
+            "env": {
+                "CHECKOUT_DEFAULT_OAUTH_CLIENT_ID": "test_client_id",
+                "CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET": "test_client_secret"
+            },
+            "showLog": true
+        }
+    ]
+}

--- a/payments/nas/client.go
+++ b/payments/nas/client.go
@@ -312,3 +312,29 @@ func (c *Client) VoidPaymentWithContext(
 
 	return &response, nil
 }
+
+func (c *Client) SearchPayments(request SearchPaymentsRequest) (*SearchPaymentsResponse, error) {
+	return c.SearchPaymentsWithContext(context.Background(), request)
+}
+
+func (c *Client) SearchPaymentsWithContext(ctx context.Context, request SearchPaymentsRequest) (*SearchPaymentsResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SearchPaymentsResponse
+	err = c.apiClient.PostWithContext(
+		ctx,
+		common.BuildPath(payments.PathPayments, "search"),
+		auth,
+		request,
+		&response,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/payments/nas/client_test.go
+++ b/payments/nas/client_test.go
@@ -1326,8 +1326,71 @@ func TestSearchPayments(t *testing.T) {
 			},
 		},
 		{
-			name:    "when request invalid then return error",
-			request: SearchPaymentsRequest{},
+			name:    "when request has invalid input then return bad request",
+			request: buildSearchPaymentsRequest(),
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.CheckoutAPIError{
+						StatusCode: http.StatusBadRequest,
+						Status:     "400 Bad Request",
+					})
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusBadRequest, chkErr.StatusCode)
+			},
+		},
+		{
+			name:    "when unauthorized then return error",
+			request: buildSearchPaymentsRequest(),
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.CheckoutAPIError{
+						StatusCode: http.StatusUnauthorized,
+						Status:     "401 Unauthorized",
+					})
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnauthorized, chkErr.StatusCode)
+			},
+		},
+		{
+			name:    "when forbidden then return error",
+			request: buildSearchPaymentsRequest(),
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.CheckoutAPIError{
+						StatusCode: http.StatusForbidden,
+						Status:     "403 Forbidden",
+					})
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusForbidden, chkErr.StatusCode)
+			},
+		},
+		{
+			name:    "when query validation fails then return error",
+			request: SearchPaymentsRequest{Query: "invalid::query"},
 			getAuthorization: func(m *mock.Mock) mock.Call {
 				return *m.On("GetAuthorization", mock.Anything).
 					Return(&configuration.SdkAuthorization{}, nil)

--- a/payments/nas/client_test.go
+++ b/payments/nas/client_test.go
@@ -1277,3 +1277,127 @@ func TestVoidPayment(t *testing.T) {
 		})
 	}
 }
+
+// tests
+
+func TestSearchPayments(t *testing.T) {
+	cases := []struct {
+		name             string
+		request          SearchPaymentsRequest
+		getAuthorization func(*mock.Mock) mock.Call
+		apiPost          func(*mock.Mock) mock.Call
+		checker          func(*SearchPaymentsResponse, error)
+	}{
+		{
+			name:    "when request is correct then return search results",
+			request: buildSearchPaymentsRequest(),
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil).
+					Run(func(args mock.Arguments) {
+						respMapping := args.Get(4).(*SearchPaymentsResponse)
+						*respMapping = buildSearchPaymentsResponse()
+					})
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, err)
+				assertSearchPaymentsResponse(t, response)
+			},
+		},
+		{
+			name: "when credentials invalid then return error",
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(nil, errors.CheckoutAuthorizationError("Invalid authorization type"))
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAuthorizationError)
+				assert.Equal(t, "Invalid authorization type", chkErr.Error())
+			},
+		},
+		{
+			name:    "when request invalid then return error",
+			request: SearchPaymentsRequest{},
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.CheckoutAPIError{
+						StatusCode: http.StatusUnprocessableEntity,
+						Status:     "422 Unprocessable Entity",
+						Data: &errors.ErrorDetails{
+							ErrorType:  "request_invalid",
+							ErrorCodes: []string{"query_invalid"},
+						},
+					})
+			},
+			checker: func(response *SearchPaymentsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnprocessableEntity, chkErr.StatusCode)
+				assert.Equal(t, "request_invalid", chkErr.Data.ErrorType)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiClient := new(mocks.ApiClientMock)
+			credentials := new(mocks.CredentialsMock)
+			environment := new(mocks.EnvironmentMock)
+			enableTelemetry := true
+
+			tc.getAuthorization(&credentials.Mock)
+			tc.apiPost(&apiClient.Mock)
+
+			config := configuration.NewConfiguration(credentials, &enableTelemetry, environment, &http.Client{}, nil)
+			client := NewClient(config, apiClient)
+
+			tc.checker(client.SearchPayments(tc.request))
+		})
+	}
+}
+
+// common methods
+
+func buildSearchPaymentsRequest() SearchPaymentsRequest {
+	return SearchPaymentsRequest{
+		Query: "id:'pay_1234'",
+		Limit: 10,
+	}
+}
+
+func buildSearchPaymentsResponse() SearchPaymentsResponse {
+	return SearchPaymentsResponse{
+		HttpMetadata: mocks.HttpMetadataStatusOk,
+		Data: []GetPaymentResponse{
+			{
+				Id:       paymentId,
+				Amount:   amount,
+				Currency: currency,
+			},
+		},
+	}
+}
+
+func assertSearchPaymentsResponse(t *testing.T, response *SearchPaymentsResponse) {
+	assert.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+	assert.NotEmpty(t, response.Data)
+	assert.Equal(t, paymentId, response.Data[0].Id)
+	assert.Equal(t, amount, response.Data[0].Amount)
+	assert.Equal(t, currency, response.Data[0].Currency)
+}

--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -206,6 +206,13 @@ type (
 		Processing        *payments.ProcessingSettings `json:"processing,omitempty"`
 		Metadata          map[string]interface{}       `json:"metadata,omitempty"`
 	}
+
+	SearchPaymentsRequest struct {
+		Query string     `json:"query,omitempty"`
+		Limit int        `json:"limit,omitempty"`
+		From  *time.Time `json:"from,omitempty"`
+		To    *time.Time `json:"to,omitempty"`
+	}
 )
 
 // Response
@@ -315,6 +322,12 @@ type (
 		Skip         int                  `json:"skip,omitempty"`
 		TotalCount   int                  `json:"total_count,omitempty"`
 		Data         []GetPaymentResponse `json:"data,omitempty"`
+	}
+
+	SearchPaymentsResponse struct {
+		HttpMetadata common.HttpMetadata
+		Data         []GetPaymentResponse   `json:"data,omitempty"`
+		Links        map[string]common.Link `json:"_links"`
 	}
 
 	IncrementAuthorizationResponse struct {

--- a/test/payments_search_test.go
+++ b/test/payments_search_test.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/payments/nas"
+)
+
+// tests
+
+func TestSearchPayments(t *testing.T) {
+	t.Skip("Avoid because can create timeout in the pipeline, activate when needed")
+
+	paymentResponse := makeCardPayment(t, false, 10)
+
+	cases := []struct {
+		name    string
+		request nas.SearchPaymentsRequest
+		checker func(interface{}, error)
+	}{
+		{
+			name:    "when search is valid then return payments",
+			request: buildSearchPaymentsRequest(paymentResponse.Id),
+			checker: func(response interface{}, err error) {
+				assert.Nil(t, err)
+				assertSearchPaymentsResponse(t, response.(*nas.SearchPaymentsResponse), paymentResponse.Id)
+			},
+		},
+	}
+
+	client := OAuthApi().Payments
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			process := func() (interface{}, error) {
+				return client.SearchPayments(tc.request)
+			}
+			predicate := func(data interface{}) bool {
+				response := data.(*nas.SearchPaymentsResponse)
+				return response.Data != nil && len(response.Data) > 0
+			}
+
+			tc.checker(retriable(process, predicate, 2))
+		})
+	}
+}
+
+// common methods
+
+func buildSearchPaymentsRequest(paymentId string) nas.SearchPaymentsRequest {
+	from := time.Now().Add(-5 * time.Minute)
+	to := time.Now().Add(5 * time.Minute)
+	return nas.SearchPaymentsRequest{
+		Query: fmt.Sprintf("id:'%s'", paymentId),
+		Limit: 10,
+		From:  &from,
+		To:    &to,
+	}
+}
+
+func assertSearchPaymentsResponse(t *testing.T, response *nas.SearchPaymentsResponse, expectedPaymentId string) {
+	assert.NotNil(t, response)
+	assert.NotEmpty(t, response.Data)
+	assert.Equal(t, expectedPaymentId, response.Data[0].Id)
+}


### PR DESCRIPTION
This pull request introduces a new "search payments" feature to the NAS payments client, along with developer tooling for debugging OAuth-related tests. The main changes include new request and response types for searching payments, new client methods to support this functionality, and VSCode launch configurations to streamline running OAuth tests.

**New Search Payments Functionality:**

* Added `SearchPaymentsRequest` and `SearchPaymentsResponse` structs in `payments/nas/payments.go` to support searching payments by query, date range, and limit, and to handle paginated responses. [[1]](diffhunk://#diff-7bb8e5151097ac7e6a9a81cc04db0dd1d69c1c461a4fcaf3012e11b370cede2eR209-R215) [[2]](diffhunk://#diff-7bb8e5151097ac7e6a9a81cc04db0dd1d69c1c461a4fcaf3012e11b370cede2eR327-R332)
* Implemented `SearchPayments` and `SearchPaymentsWithContext` methods in `payments/nas/client.go` to perform payment search operations, including context-aware support and proper authorization handling.

**Developer Tooling:**

* Added `.vscode/launch.json` with configurations for debugging OAuth tests, including both real and mock credential setups, to improve developer experience when running and debugging test cases.