### PR TITLE
fix: route forward and identity clients to dedicated base URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 *.DS_Store*
 .cursor/rules/*.mdc
 .cursor/skills/endpoint-review-auto/*.md
+.claude/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -194,11 +194,14 @@ import (
 )
 
 environment := configuration.NewEnvironment(
-	"https://the.base.uri/", // the uri for all CKO operations 
-	"https://the.oauth.uri/connect/token", // the uri used for OAUTH authorization, only required for OAuth operations 
-	"https://the.files.uri/", // the uri used for Files operations, only required for Accounts module 
-	"https://the.transfers.uri/", // the uri used for Transfer operations, only required for Transfers module 
-	"https://the.balances.uri/", // the uri used for Balances operations, only required for Balances module false 
+	"https://the.base.uri/", // the uri for all CKO operations
+	"https://the.oauth.uri/connect/token", // the uri used for OAUTH authorization, only required for OAuth operations
+	"https://the.files.uri/", // the uri used for Files operations, only required for Accounts module
+	"https://the.transfers.uri/", // the uri used for Transfer operations, only required for Transfers module
+	"https://the.balances.uri/", // the uri used for Balances operations, only required for Balances module
+	"https://the.forward.uri/", // the uri used for Forward operations, only required for Forward module
+	"https://the.identity.uri/", // the uri used for Identity operations, only required for Identity modules (applicants, identity-verifications, aml-verifications, face-authentications, id-document-verifications)
+	false, // isSandbox
 )
 
 api, err := checkout.Builder().

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -12,6 +12,7 @@ type Environment interface {
 	TransfersUri() string
 	BalancesUri() string
 	ForwardUri() string
+	IdentityUri() string
 	IsSandbox() bool
 }
 
@@ -56,6 +57,7 @@ type CheckoutEnv struct {
 	transfersUri     string
 	balancesUri      string
 	forwardUri       string
+	identityUri      string
 	isSandbox        bool
 }
 
@@ -83,6 +85,10 @@ func (e *CheckoutEnv) ForwardUri() string {
 	return e.forwardUri
 }
 
+func (e *CheckoutEnv) IdentityUri() string {
+	return e.identityUri
+}
+
 func (e *CheckoutEnv) IsSandbox() bool {
 	return e.isSandbox
 }
@@ -94,6 +100,7 @@ func NewEnvironment(
 	transfersUri string,
 	balancesUri string,
 	forwardUri string,
+	identityUri string,
 	isSandbox bool,
 ) *CheckoutEnv {
 	return &CheckoutEnv{
@@ -103,6 +110,7 @@ func NewEnvironment(
 		transfersUri:     transfersUri,
 		balancesUri:      balancesUri,
 		forwardUri:       forwardUri,
+		identityUri:      identityUri,
 		isSandbox:        isSandbox}
 }
 
@@ -114,6 +122,7 @@ func Sandbox() *CheckoutEnv {
 		"https://transfers.sandbox.checkout.com",
 		"https://balances.sandbox.checkout.com",
 		"https://forward.sandbox.checkout.com",
+		"https://identity-verification.sandbox.checkout.com",
 		true)
 }
 
@@ -125,5 +134,6 @@ func Production() *CheckoutEnv {
 		"https://transfers.checkout.com/",
 		"https://balances.checkout.com/",
 		"https://forward.checkout.com",
+		"https://identity-verification.checkout.com",
 		false)
 }

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -36,7 +36,7 @@ func NewEnvironmentSubdomain(environment Environment, subdomain string) *Environ
 func createUrlWithSubdomain(originalUrl string, subdomain string) string {
 	newEnvironment := originalUrl
 
-	regex := regexp.MustCompile("^[a-z0-9]+(-[a-z0-9]+)*$")
+	regex := regexp.MustCompile("^(?:pl-)?[a-z0-9]+$")
 
 	if regex.MatchString(subdomain) {
 		merchantUrl, err := url.Parse(originalUrl)

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -11,6 +11,7 @@ type Environment interface {
 	FilesUri() string
 	TransfersUri() string
 	BalancesUri() string
+	ForwardUri() string
 	IsSandbox() bool
 }
 
@@ -34,7 +35,7 @@ func NewEnvironmentSubdomain(environment Environment, subdomain string) *Environ
 func createUrlWithSubdomain(originalUrl string, subdomain string) string {
 	newEnvironment := originalUrl
 
-	regex := regexp.MustCompile("^[0-9a-z]+$")
+	regex := regexp.MustCompile("^[a-z0-9]+(-[a-z0-9]+)*$")
 
 	if regex.MatchString(subdomain) {
 		merchantUrl, err := url.Parse(originalUrl)
@@ -54,6 +55,7 @@ type CheckoutEnv struct {
 	filesUri         string
 	transfersUri     string
 	balancesUri      string
+	forwardUri       string
 	isSandbox        bool
 }
 
@@ -77,6 +79,10 @@ func (e *CheckoutEnv) BalancesUri() string {
 	return e.balancesUri
 }
 
+func (e *CheckoutEnv) ForwardUri() string {
+	return e.forwardUri
+}
+
 func (e *CheckoutEnv) IsSandbox() bool {
 	return e.isSandbox
 }
@@ -87,6 +93,7 @@ func NewEnvironment(
 	filesUri string,
 	transfersUri string,
 	balancesUri string,
+	forwardUri string,
 	isSandbox bool,
 ) *CheckoutEnv {
 	return &CheckoutEnv{
@@ -95,15 +102,18 @@ func NewEnvironment(
 		filesUri:         filesUri,
 		transfersUri:     transfersUri,
 		balancesUri:      balancesUri,
+		forwardUri:       forwardUri,
 		isSandbox:        isSandbox}
 }
 
 func Sandbox() *CheckoutEnv {
-	return NewEnvironment("https://api.sandbox.checkout.com",
+	return NewEnvironment(
+		"https://api.sandbox.checkout.com",
 		"https://access.sandbox.checkout.com/connect/token",
 		"https://files.sandbox.checkout.com",
 		"https://transfers.sandbox.checkout.com",
 		"https://balances.sandbox.checkout.com",
+		"https://forward.sandbox.checkout.com",
 		true)
 }
 
@@ -114,5 +124,6 @@ func Production() *CheckoutEnv {
 		"https://files.checkout.com/",
 		"https://transfers.checkout.com/",
 		"https://balances.checkout.com/",
+		"https://forward.checkout.com",
 		false)
 }

--- a/configuration/oauth_scopes.go
+++ b/configuration/oauth_scopes.go
@@ -29,6 +29,7 @@ const (
 	GatewayPaymentDetails       = "gateway:payment-details"
 	GatewayPaymentRefunds       = "gateway:payment-refunds"
 	GatewayPaymentVoids         = "gateway:payment-voids"
+	IdentityVerification        = "identity-verification"
 	IssuingCardMgmt             = "issuing:card-mgmt"
 	IssuingClient               = "issuing:client"
 	IssuingControlsRead         = "issuing:controls-read"

--- a/mocks/environment_mock.go
+++ b/mocks/environment_mock.go
@@ -30,6 +30,10 @@ func (m *EnvironmentMock) ForwardUri() string {
 	return ""
 }
 
+func (m *EnvironmentMock) IdentityUri() string {
+	return ""
+}
+
 func (m *EnvironmentMock) IsSandbox() bool {
 	return true
 }

--- a/mocks/environment_mock.go
+++ b/mocks/environment_mock.go
@@ -26,6 +26,10 @@ func (m *EnvironmentMock) BalancesUri() string {
 	return ""
 }
 
+func (m *EnvironmentMock) ForwardUri() string {
+	return ""
+}
+
 func (m *EnvironmentMock) IsSandbox() bool {
 	return true
 }

--- a/nas/checkout_api.go
+++ b/nas/checkout_api.go
@@ -116,11 +116,12 @@ func CheckoutApi(configuration *configuration.Configuration) *Api {
 	api.AgenticCommerce = agenticcommerce.NewClient(configuration, apiClient)
 	api.ComplianceRequests = compliancerequests.NewClient(configuration, apiClient)
 	api.PaymentMethods = paymentmethods.NewClient(configuration, apiClient)
-	api.AmlScreening = amlscreening.NewClient(configuration, apiClient)
-	api.Applicants = applicants.NewClient(configuration, apiClient)
-	api.FaceAuthentication = faceauthentication.NewClient(configuration, apiClient)
-	api.IdDocumentVerification = iddocumentverification.NewClient(configuration, apiClient)
-	api.IdentityVerification = identityverification.NewClient(configuration, apiClient)
+	identityClient := buildIdentityClient(configuration)
+	api.AmlScreening = amlscreening.NewClient(configuration, identityClient)
+	api.Applicants = applicants.NewClient(configuration, identityClient)
+	api.FaceAuthentication = faceauthentication.NewClient(configuration, identityClient)
+	api.IdDocumentVerification = iddocumentverification.NewClient(configuration, identityClient)
+	api.IdentityVerification = identityverification.NewClient(configuration, identityClient)
 
 	api.Ideal = ideal.NewClient(configuration, apiClient)
 	api.Klarna = klarna.NewClient(configuration, apiClient)
@@ -149,4 +150,8 @@ func buildTransfersClient(configuration *configuration.Configuration) client.Htt
 
 func buildForwardClient(configuration *configuration.Configuration) client.HttpClient {
 	return client.NewApiClient(configuration, configuration.Environment.ForwardUri())
+}
+
+func buildIdentityClient(configuration *configuration.Configuration) client.HttpClient {
+	return client.NewApiClient(configuration, configuration.Environment.IdentityUri())
 }

--- a/nas/checkout_api.go
+++ b/nas/checkout_api.go
@@ -108,7 +108,7 @@ func CheckoutApi(configuration *configuration.Configuration) *Api {
 	api.Contexts = contexts.NewClient(configuration, apiClient)
 	api.PaymentSessions = payment_sessions.NewClient(configuration, apiClient)
 	api.PaymentSetups = setups.NewClient(configuration, apiClient)
-	api.Forward = forward.NewClient(configuration, apiClient)
+	api.Forward = forward.NewClient(configuration, buildForwardClient(configuration))
 	api.ApplePay = applepay.NewClient(configuration, apiClient)
 	api.GooglePay = googlepay.NewClient(configuration, apiClient)
 	api.NetworkTokens = networktokens.NewClient(configuration, apiClient)
@@ -145,4 +145,8 @@ func buildBalancesClient(configuration *configuration.Configuration) client.Http
 
 func buildTransfersClient(configuration *configuration.Configuration) client.HttpClient {
 	return client.NewApiClient(configuration, configuration.Environment.TransfersUri())
+}
+
+func buildForwardClient(configuration *configuration.Configuration) client.HttpClient {
+	return client.NewApiClient(configuration, configuration.Environment.ForwardUri())
 }

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -28,7 +28,7 @@ func TestShouldCreateConfigurationWithSubdomain(t *testing.T) {
 		{"12345678", "https://12345678.api.sandbox.checkout.com", "https://12345678.access.sandbox.checkout.com/connect/token"},
 		{"abcdefgh", "https://abcdefgh.api.sandbox.checkout.com", "https://abcdefgh.access.sandbox.checkout.com/connect/token"},
 		{"1234doma", "https://1234doma.api.sandbox.checkout.com", "https://1234doma.access.sandbox.checkout.com/connect/token"},
-		{"test-123", "https://test-123.api.sandbox.checkout.com", "https://test-123.access.sandbox.checkout.com/connect/token"},
+		{"pl-vkuhvk4v", "https://pl-vkuhvk4v.api.sandbox.checkout.com", "https://pl-vkuhvk4v.access.sandbox.checkout.com/connect/token"},
 		{"pl-abc123", "https://pl-abc123.api.sandbox.checkout.com", "https://pl-abc123.access.sandbox.checkout.com/connect/token"},
 	}
 
@@ -61,6 +61,9 @@ func TestShouldCreateConfigurationWithBadSubdomain(t *testing.T) {
 		{"foo-", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 		{"-foo", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 		{"ABC", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"test-123", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"foo-bar", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"pl-", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 	}
 
 	for _, tc := range testCases {

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -28,6 +28,8 @@ func TestShouldCreateConfigurationWithSubdomain(t *testing.T) {
 		{"12345678", "https://12345678.api.sandbox.checkout.com", "https://12345678.access.sandbox.checkout.com/connect/token"},
 		{"abcdefgh", "https://abcdefgh.api.sandbox.checkout.com", "https://abcdefgh.access.sandbox.checkout.com/connect/token"},
 		{"1234doma", "https://1234doma.api.sandbox.checkout.com", "https://1234doma.access.sandbox.checkout.com/connect/token"},
+		{"test-123", "https://test-123.api.sandbox.checkout.com", "https://test-123.access.sandbox.checkout.com/connect/token"},
+		{"pl-abc123", "https://pl-abc123.api.sandbox.checkout.com", "https://pl-abc123.access.sandbox.checkout.com/connect/token"},
 	}
 
 	for _, tc := range testCases {
@@ -56,6 +58,9 @@ func TestShouldCreateConfigurationWithBadSubdomain(t *testing.T) {
 		{" - ", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 		{"a b", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 		{"ab c1", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"foo-", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"-foo", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
+		{"ABC", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
 	}
 
 	for _, tc := range testCases {
@@ -81,4 +86,5 @@ func TestShouldCreateConfigurationWithSubdomainForProduction(t *testing.T) {
 	assert.NotNil(t, config)
 	assert.Equal(t, "https://1234prod.api.checkout.com", config.EnvironmentSubdomain.ApiUrl)
 	assert.Equal(t, "https://1234prod.access.checkout.com/connect/token", config.EnvironmentSubdomain.AuthorizationUrl)
+	assert.Equal(t, "https://forward.checkout.com", config.Environment.ForwardUri())
 }

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -87,4 +87,27 @@ func TestShouldCreateConfigurationWithSubdomainForProduction(t *testing.T) {
 	assert.Equal(t, "https://1234prod.api.checkout.com", config.EnvironmentSubdomain.ApiUrl)
 	assert.Equal(t, "https://1234prod.access.checkout.com/connect/token", config.EnvironmentSubdomain.AuthorizationUrl)
 	assert.Equal(t, "https://forward.checkout.com", config.Environment.ForwardUri())
+	assert.Equal(t, "https://identity-verification.checkout.com", config.Environment.IdentityUri())
+}
+
+func TestShouldHaveCorrectSandboxUrls(t *testing.T) {
+	env := configuration.Sandbox()
+
+	assert.Equal(t, "https://api.sandbox.checkout.com", env.BaseUri())
+	assert.Equal(t, "https://files.sandbox.checkout.com", env.FilesUri())
+	assert.Equal(t, "https://transfers.sandbox.checkout.com", env.TransfersUri())
+	assert.Equal(t, "https://balances.sandbox.checkout.com", env.BalancesUri())
+	assert.Equal(t, "https://forward.sandbox.checkout.com", env.ForwardUri())
+	assert.Equal(t, "https://identity-verification.sandbox.checkout.com", env.IdentityUri())
+}
+
+func TestShouldHaveCorrectProductionUrls(t *testing.T) {
+	env := configuration.Production()
+
+	assert.Equal(t, "https://api.checkout.com", env.BaseUri())
+	assert.Equal(t, "https://files.checkout.com/", env.FilesUri())
+	assert.Equal(t, "https://transfers.checkout.com/", env.TransfersUri())
+	assert.Equal(t, "https://balances.checkout.com/", env.BalancesUri())
+	assert.Equal(t, "https://forward.checkout.com", env.ForwardUri())
+	assert.Equal(t, "https://identity-verification.checkout.com", env.IdentityUri())
 }

--- a/test/telemetry_test.go
+++ b/test/telemetry_test.go
@@ -94,6 +94,7 @@ func createMockEnvironment(mockServerURL string) *configuration.CheckoutEnv {
 		mockServerURL, // filesUri
 		mockServerURL, // transfersUri
 		mockServerURL, // balancesUri
+		mockServerURL, // forwardUri
 		true,          // isSandbox
 	)
 }

--- a/test/telemetry_test.go
+++ b/test/telemetry_test.go
@@ -95,6 +95,7 @@ func createMockEnvironment(mockServerURL string) *configuration.CheckoutEnv {
 		mockServerURL, // transfersUri
 		mockServerURL, // balancesUri
 		mockServerURL, // forwardUri
+		mockServerURL, // identityUri
 		true,          // isSandbox
 	)
 }


### PR DESCRIPTION
## Summary

The forward service and the identity-verification services (applicants, identity-verifications, aml-verifications, face-authentications, id-document-verifications) live on their own hosts in the swagger spec, not under `api.checkout.com`. This PR adds dedicated URIs for both and routes the corresponding clients through them. It also tightens the subdomain validation regex to match the AWS PrivateLink prefix format documented at https://www.checkout.com/docs/developer-resources/api/private-connections/aws-privatelink — `^(?:pl-)?[a-z0-9]+$` (alphanumeric, optionally prefixed by the literal `pl-`). Finally, it exposes the `identity-verification` OAuth scope as a typed constant.

## Changes

- `configuration/environment.go` — adds `ForwardUri()` and `IdentityUri()` to the `Environment` interface; adds `forwardUri`/`identityUri` fields and getters on `CheckoutEnv`; extends `NewEnvironment` signature with both URIs; adds sandbox/production values; tightens subdomain regex to `^(?:pl-)?[a-z0-9]+$`
- `configuration/oauth_scopes.go` — adds `IdentityVerification = "identity-verification"`
- `nas/checkout_api.go` — adds `buildForwardClient` and `buildIdentityClient` helpers; routes `api.Forward` to the forward URL; caches the identity `ApiClient` once and reuses it across `AmlScreening`, `Applicants`, `FaceAuthentication`, `IdDocumentVerification`, `IdentityVerification`
- `mocks/environment_mock.go` — adds `ForwardUri()` and `IdentityUri()` stubs
- `test/configuration_api_test.go` — adds `pl-vkuhvk4v` (docs example) and `pl-abc123` to the accepted subdomains; moves `test-123` to the rejected list and adds `foo-bar`, `pl-` (bare); asserts `ForwardUri()`/`IdentityUri()` on production env; adds `TestShouldHaveCorrectSandboxUrls` / `TestShouldHaveCorrectProductionUrls` covering every URI
- `test/telemetry_test.go` — passes the new URIs to the mock environment factory
- `README.md` — updates the `NewEnvironment` example to reflect the new signature

## API Reference

- `https://forward.checkout.com` / `https://forward.sandbox.checkout.com` — forward service (`POST /forward` *(beta)*, `GET /forward/{id}` *(beta)*, `POST /forward/secrets`, `GET|POST|DELETE /forward/secrets/{name}`). Scopes: `forward` (plus `forward:secrets` for secrets endpoints).
- `https://identity-verification.checkout.com` / `https://identity-verification.sandbox.checkout.com` — identity services (`/applicants`, `/identity-verifications` *(beta)*, `/aml-verifications` *(beta)*, `/face-authentications` *(beta)*, `/id-document-verifications` *(beta)*). Scope: `identity-verification`.
- `https://pl-{prefix}.api.{sandbox.,}checkout.com` — AWS PrivateLink subdomain format

## Breaking changes

- `configuration.NewEnvironment` signature now requires `forwardUri` and `identityUri` parameters
- `configuration.Environment` interface adds `ForwardUri()` and `IdentityUri()` methods — custom implementations must add them
- The subdomain regex is now stricter: arbitrary hyphenated subdomains like `test-123` or `foo-bar-baz` are rejected. Only plain alphanumeric (`vkuhvk4v`) or the literal PrivateLink form (`pl-vkuhvk4v`) are accepted.

## README

Updated.