### PR TITLE
feature/INT-1635 - Transaction Link Identifier update

### DIFF
--- a/payments/payments.go
+++ b/payments/payments.go
@@ -642,6 +642,7 @@ type (
 		ContinuationPayload              string           `json:"continuation_payload,omitempty"`
 		Pun                              string           `json:"pun,omitempty"`
 		MerchantCategoryCode             string           `json:"merchant_category_code,omitempty"`
+		SchemeTransactionLinkId          string           `json:"scheme_transaction_link_id,omitempty"`
 	}
 
 	PaymentRetryResponse struct {
@@ -911,6 +912,7 @@ type (
 		PartnerMerchantAdviceCode        string                           `json:"partner_merchant_advice_code,omitempty"`
 		AccommodationData                []AccommodationData              `json:"accommodation_data,omitempty"`
 		AirlineData                      []AirlineData                    `json:"airline_data,omitempty"`
+		SchemeTransactionLinkId          string                           `json:"scheme_transaction_link_id,omitempty"`
 	}
 
 	ProviderAuthorizedPaymentMethod struct {

--- a/payments/processing_data_test.go
+++ b/payments/processing_data_test.go
@@ -18,6 +18,7 @@ import (
 //   - partner_code
 //   - partner_response_code
 //   - fallback_source_used
+//   - scheme_transaction_link_id (Mastercard Transaction Link Identifier)
 func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 	payload := `{
 		"scheme":"ACCEL",
@@ -27,6 +28,7 @@ func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 		"partner_code":"902111",
 		"partner_response_code":"DECLINED",
 		"fallback_source_used":true,
+		"scheme_transaction_link_id":"MTL-XYZ-789",
 		"accommodation_data":[{"name":"Grand Hotel"}],
 		"airline_data":[{"ticket":{"number":"045-21351455613"}}]
 	}`
@@ -42,6 +44,7 @@ func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 	assert.Equal(t, "902111", data.PartnerCode)
 	assert.Equal(t, "DECLINED", data.PartnerResponseCode)
 	assert.True(t, data.FallbackSourceUsed)
+	assert.Equal(t, "MTL-XYZ-789", data.SchemeTransactionLinkId)
 
 	assert.Len(t, data.AccommodationData, 1)
 	assert.Equal(t, "Grand Hotel", data.AccommodationData[0].Name)
@@ -68,6 +71,45 @@ func TestProcessingData_LeavesNewFieldsZeroWhenAbsent(t *testing.T) {
 	assert.Empty(t, data.PartnerCode)
 	assert.Empty(t, data.PartnerResponseCode)
 	assert.False(t, data.FallbackSourceUsed)
+	assert.Empty(t, data.SchemeTransactionLinkId)
 	assert.Nil(t, data.AccommodationData)
 	assert.Nil(t, data.AirlineData)
+}
+
+// Verifies the Mastercard Transaction Link Identifier deserializes from the
+// processing object returned in a payment response (PaymentProcessing), and
+// serializes back to its snake_case wire name.
+func TestPaymentProcessing_SchemeTransactionLinkId(t *testing.T) {
+	payload := `{
+		"retrieval_reference_number":"RRN001",
+		"acquirer_transaction_id":"ACQ001",
+		"scheme":"Mastercard",
+		"scheme_transaction_link_id":"MTL-XYZ-789"
+	}`
+
+	var processing PaymentProcessing
+	err := json.Unmarshal([]byte(payload), &processing)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "RRN001", processing.RetrievalReferenceNumber)
+	assert.Equal(t, "ACQ001", processing.AcquirerTransactionId)
+	assert.Equal(t, "Mastercard", processing.Scheme)
+	assert.Equal(t, "MTL-XYZ-789", processing.SchemeTransactionLinkId)
+
+	marshalled, err := json.Marshal(PaymentProcessing{SchemeTransactionLinkId: "MTL-001"})
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"scheme_transaction_link_id":"MTL-001"`)
+}
+
+// Verifies the field stays zero-valued when absent from the payment response
+// processing object (it is optional and only populated for Mastercard transactions).
+func TestPaymentProcessing_SchemeTransactionLinkIdAbsent(t *testing.T) {
+	payload := `{"retrieval_reference_number":"RRN001"}`
+
+	var processing PaymentProcessing
+	err := json.Unmarshal([]byte(payload), &processing)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "RRN001", processing.RetrievalReferenceNumber)
+	assert.Empty(t, processing.SchemeTransactionLinkId)
 }

--- a/test/payments_request_test.go
+++ b/test/payments_request_test.go
@@ -431,6 +431,10 @@ func assertProcessing(t *testing.T, response *nas.PaymentResponse) {
 	assert.NotEmpty(t, processing)
 	assert.NotEmpty(t, processing.AcquirerTransactionId)
 	assert.NotEmpty(t, processing.RetrievalReferenceNumber)
+	// Mastercard Transaction Link Identifier - optional, only populated for Mastercard
+	// transactions. The test card is not Mastercard, so the field is typically absent.
+	// Referencing it confirms the SDK exposes the field on the payment response.
+	_ = processing.SchemeTransactionLinkId
 }
 
 func assertRisk(t *testing.T, response *nas.PaymentResponse) {


### PR DESCRIPTION
This pull request adds support for the Mastercard Transaction Link Identifier (`scheme_transaction_link_id`) across the payments API, ensuring it is correctly handled in both the main data structures and their serialization/deserialization logic. Comprehensive tests are also included to verify the new field’s behavior in different scenarios.

**Support for Mastercard Transaction Link Identifier:**

* Added the `SchemeTransactionLinkId` field to the `PaymentProcessing` and `PaymentProcessingData` structs in `payments.go`, allowing the Mastercard Transaction Link Identifier to be captured and surfaced in payment processing data. [[1]](diffhunk://#diff-27713d6983bc85f6078d84b119f33d83ca6c3cda6ce906e87ddb931724e0d287R645) [[2]](diffhunk://#diff-27713d6983bc85f6078d84b119f33d83ca6c3cda6ce906e87ddb931724e0d287R915)

**Testing and validation:**

* Updated and expanded tests in `payments/processing_data_test.go` to:
  - Assert correct unmarshaling and marshaling of the new field.
  - Ensure the field is set when present and remains empty when absent.
  - Document the purpose and expected behavior of the field in test comments. [[1]](diffhunk://#diff-3fa6ff02a0a4bba10c70b98c3a4f47cf849d4ce4a6fc2a6ba2ded7db7a66b005R21) [[2]](diffhunk://#diff-3fa6ff02a0a4bba10c70b98c3a4f47cf849d4ce4a6fc2a6ba2ded7db7a66b005R31) [[3]](diffhunk://#diff-3fa6ff02a0a4bba10c70b98c3a4f47cf849d4ce4a6fc2a6ba2ded7db7a66b005R47) [[4]](diffhunk://#diff-3fa6ff02a0a4bba10c70b98c3a4f47cf849d4ce4a6fc2a6ba2ded7db7a66b005R74-R115)
* Updated `test/payments_request_test.go` to reference the new field in assertions, confirming it is exposed by the SDK even when not populated.