### PR TITLE
fix: optional bool serialization + missing payment request fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 .cursor/rules/*.mdc
 .claude/rules/*.md
 .cursor/skills/endpoint-review-auto/*.md
+CLAUDE.md

--- a/payments/hosted/hosted.go
+++ b/payments/hosted/hosted.go
@@ -73,6 +73,10 @@ type (
 		CaptureOn                  *time.Time                               `json:"capture_on,omitempty"`
 		Instruction                *payments.PaymentInstruction             `json:"instruction,omitempty"`
 		PaymentMethodConfiguration *payments.PaymentMethodConfiguration     `json:"payment_method_configuration,omitempty"`
+		// AuthorizationType is the authorization type. Defaults to Final.
+		AuthorizationType nas.AuthorizationType `json:"authorization_type,omitempty" default:"Final"`
+		// PaymentPlan is the information to process a recurring payment request. To be used when the payment_type is Recurring.
+		PaymentPlan *payments.PaymentPlan `json:"payment_plan,omitempty"`
 	}
 )
 

--- a/payments/hosted/hosted_fields_test.go
+++ b/payments/hosted/hosted_fields_test.go
@@ -1,0 +1,41 @@
+package hosted
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/payments"
+	"github.com/checkout/checkout-sdk-go/v2/payments/nas"
+)
+
+// Verifies the fields recently aligned with the Checkout.com swagger spec
+// (HostedPaymentsRequest) serialize to their snake_case wire names.
+//   - authorization_type
+//   - payment_plan
+func TestPaymentHostedRequest_AuthorizationTypeAndPaymentPlan(t *testing.T) {
+	request := PaymentHostedRequest{
+		AuthorizationType: nas.EstimatedAuthorizationType,
+		PaymentPlan: &payments.PaymentPlan{
+			AmountVariability:   payments.FixedAVT,
+			DaysBetweenPayments: 28,
+		},
+	}
+
+	marshalled, err := json.Marshal(request)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"authorization_type":"Estimated"`)
+	assert.Contains(t, string(marshalled), `"payment_plan":`)
+	assert.Contains(t, string(marshalled), `"days_between_payments":28`)
+}
+
+// Verifies the new fields are omitted when unset.
+func TestPaymentHostedRequest_OmitsNewFieldsWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentHostedRequest{})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "authorization_type")
+	assert.NotContains(t, string(marshalled), "payment_plan")
+}

--- a/payments/links/links.go
+++ b/payments/links/links.go
@@ -71,6 +71,10 @@ type (
 		CaptureOn                  *time.Time                               `json:"capture_on,omitempty"`
 		Instruction                *payments.PaymentInstruction             `json:"instruction,omitempty"`
 		PaymentMethodConfiguration *payments.PaymentMethodConfiguration     `json:"payment_method_configuration,omitempty"`
+		// AuthorizationType is the authorization type. Defaults to Final.
+		AuthorizationType nas.AuthorizationType `json:"authorization_type,omitempty" default:"Final"`
+		// PaymentPlan is the information to process a recurring payment request. To be used when the payment_type is Recurring.
+		PaymentPlan *payments.PaymentPlan `json:"payment_plan,omitempty"`
 	}
 )
 

--- a/payments/links/links_fields_test.go
+++ b/payments/links/links_fields_test.go
@@ -1,0 +1,41 @@
+package links
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/payments"
+	"github.com/checkout/checkout-sdk-go/v2/payments/nas"
+)
+
+// Verifies the fields recently aligned with the Checkout.com swagger spec
+// (PaymentLinksRequest) serialize to their snake_case wire names.
+//   - authorization_type
+//   - payment_plan
+func TestPaymentLinkRequest_AuthorizationTypeAndPaymentPlan(t *testing.T) {
+	request := PaymentLinkRequest{
+		AuthorizationType: nas.EstimatedAuthorizationType,
+		PaymentPlan: &payments.PaymentPlan{
+			AmountVariability:   payments.FixedAVT,
+			DaysBetweenPayments: 28,
+		},
+	}
+
+	marshalled, err := json.Marshal(request)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"authorization_type":"Estimated"`)
+	assert.Contains(t, string(marshalled), `"payment_plan":`)
+	assert.Contains(t, string(marshalled), `"days_between_payments":28`)
+}
+
+// Verifies the new fields are omitted when unset.
+func TestPaymentLinkRequest_OmitsNewFieldsWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentLinkRequest{})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "authorization_type")
+	assert.NotContains(t, string(marshalled), "payment_plan")
+}

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -510,8 +510,8 @@ type (
 		Incognito         bool      `json:"incognito,omitempty"`
 		Jailbroken        bool      `json:"jailbroken,omitempty"`
 		Rooted            bool      `json:"rooted,omitempty"`
-		JavaEnabled       bool      `json:"java_enabled,omitempty"`
-		JavascriptEnabled bool      `json:"javascript_enabled,omitempty"`
+		JavaEnabled       *bool     `json:"java_enabled,omitempty"`
+		JavascriptEnabled *bool     `json:"javascript_enabled,omitempty"`
 		Language          string    `json:"language,omitempty"`
 		ColorDepth        string    `json:"color_depth,omitempty"`
 		ScreenHeight      string    `json:"screen_height,omitempty"`

--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -100,6 +100,10 @@ type (
 		EnabledPaymentMethods      []PaymentMethodsType                     `json:"enabled_payment_methods,omitempty"`
 		DisabledPaymentMethods     []PaymentMethodsType                     `json:"disabled_payment_methods,omitempty"`
 		CustomerRetry              *payments.PaymentRetryRequest            `json:"customer_retry,omitempty"`
+		// AuthorizationType is the authorization type. Defaults to Final.
+		AuthorizationType nas.AuthorizationType `json:"authorization_type,omitempty" default:"Final"`
+		// PaymentPlan is the information to process a recurring payment request. To be used when the payment_type is Recurring.
+		PaymentPlan *payments.PaymentPlan `json:"payment_plan,omitempty"`
 		// Deprecated: IpAddress is deprecated. Use alternative fields for client identification.
 		IpAddress string `json:"ip_address,omitempty"`
 	}

--- a/payments/sessions/sessions_fields_test.go
+++ b/payments/sessions/sessions_fields_test.go
@@ -1,0 +1,41 @@
+package payment_sessions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/payments"
+	"github.com/checkout/checkout-sdk-go/v2/payments/nas"
+)
+
+// Verifies the fields recently aligned with the Checkout.com swagger spec
+// (CreatePaymentSessionsBaseRequest) serialize to their snake_case wire names.
+//   - authorization_type
+//   - payment_plan
+func TestPaymentSessionsRequest_AuthorizationTypeAndPaymentPlan(t *testing.T) {
+	request := PaymentSessionsRequest{
+		AuthorizationType: nas.EstimatedAuthorizationType,
+		PaymentPlan: &payments.PaymentPlan{
+			AmountVariability:   payments.FixedAVT,
+			DaysBetweenPayments: 28,
+		},
+	}
+
+	marshalled, err := json.Marshal(request)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"authorization_type":"Estimated"`)
+	assert.Contains(t, string(marshalled), `"payment_plan":`)
+	assert.Contains(t, string(marshalled), `"days_between_payments":28`)
+}
+
+// Verifies the new fields are omitted when unset.
+func TestPaymentSessionsRequest_OmitsNewFieldsWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentSessionsRequest{})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "authorization_type")
+	assert.NotContains(t, string(marshalled), "payment_plan")
+}

--- a/sessions/channels/channels.go
+++ b/sessions/channels/channels.go
@@ -71,8 +71,8 @@ type (
 		ChannelData
 		ThreeDsMethodCompletion common.ThreeDsMethodCompletion `json:"three_ds_method_completion,omitempty" default:"u"`
 		AcceptHeader            string                         `json:"accept_header,omitempty"`
-		JavaEnabled             bool                           `json:"java_enabled,omitempty"`
-		JavascriptEnabled       bool                           `json:"javascript_enabled,omitempty"`
+		JavaEnabled             *bool                          `json:"java_enabled,omitempty"`
+		JavascriptEnabled       *bool                          `json:"javascript_enabled,omitempty"`
 		Language                string                         `json:"language,omitempty"`
 		ColorDepth              string                         `json:"color_depth,omitempty"`
 		ScreenHeight            string                         `json:"screen_height,omitempty"`

--- a/test/sessions_test.go
+++ b/test/sessions_test.go
@@ -343,8 +343,8 @@ func TestCompleteSession(t *testing.T) {
 func getBrowserChannel() channels.Channel {
 	c := channels.NewBrowserSession()
 	c.AcceptHeader = "Accept:  *.*, q=0.1"
-	c.JavaEnabled = true
-	c.JavascriptEnabled = true
+	c.JavaEnabled = Bool(true)
+	c.JavascriptEnabled = Bool(true)
 	c.Language = "FR-fr"
 	c.ColorDepth = "16"
 	c.ScreenWidth = "1920"


### PR DESCRIPTION
## Summary

Two related fixes found while running the daily swagger review against the Go SDK.

### 1. `omitempty`-on-bool bug (`java_enabled` / `javascript_enabled`)
These were `bool` with `omitempty`, so an explicit `false` was indistinguishable from the zero value and got **dropped from the JSON payload** — a merchant could not send `java_enabled: false`. Changed to `*bool` (the idiom already used elsewhere in the SDK for optional booleans), so `false` serializes correctly and the field is still omitted when `nil`.

- `sessions/channels` `browserSession` (3DS browser channel data)
- `payments` `DeviceDetails` (collect-data device data)

> Reported by another team's tooling as affecting any Go backend using collect-data.

### 2. Missing payment request fields — `authorization_type` + `payment_plan`
Added to align with the swagger spec (changelog 2026-06-03 / 2026-06-15). No new types needed — reuses `nas.AuthorizationType` (`Final`/`Estimated`) and `payments.PaymentPlan`.

- `PaymentHostedRequest` (hosted payments)
- `PaymentLinkRequest` (payment links)
- `PaymentSessionsRequest` (payment sessions)

### Tests
Added schema serialization tests for the new fields (snake_case wire names + `omitempty` behavior).

## Verification
- `go build ./...` clean
- New test files compile and type-check (`go test -c`)

> Note: tests were not executed locally due to an x86_64-Go-under-Rosetta toolchain issue on the dev machine (`dyld: missing LC_UUID`), which affects all tests in the repo. CI will run them.