### PR TITLE
feature/INT-1636 - GetFaceAuthenticationAttemptAssets + PaymentPlan updates

### DIFF
--- a/identities/faceauthentication/client.go
+++ b/identities/faceauthentication/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/client"
 	"github.com/checkout/checkout-sdk-go/v2/common"
 	"github.com/checkout/checkout-sdk-go/v2/configuration"
+	"github.com/checkout/checkout-sdk-go/v2/identities"
 )
 
 type Client struct {
@@ -127,6 +128,30 @@ func (c *Client) GetFaceAuthenticationAttemptWithContext(ctx context.Context, fa
 
 	var response FaceAuthenticationAttemptResponse
 	err = c.apiClient.GetWithContext(ctx, common.BuildPath(faceAuthenticationsPath, faceAuthenticationId, attemptsPath, attemptId), auth, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetFaceAuthenticationAttemptAssets(faceAuthenticationId, attemptId string, query identities.AttemptAssetsQueryFilter) (*FaceAuthenticationAttemptAssetsResponse, error) {
+	return c.GetFaceAuthenticationAttemptAssetsWithContext(context.Background(), faceAuthenticationId, attemptId, query)
+}
+
+func (c *Client) GetFaceAuthenticationAttemptAssetsWithContext(ctx context.Context, faceAuthenticationId, attemptId string, query identities.AttemptAssetsQueryFilter) (*FaceAuthenticationAttemptAssetsResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := common.BuildQueryPath(common.BuildPath(faceAuthenticationsPath, faceAuthenticationId, attemptsPath, attemptId, assetsPath), query)
+	if err != nil {
+		return nil, err
+	}
+
+	var response FaceAuthenticationAttemptAssetsResponse
+	err = c.apiClient.GetWithContext(ctx, url, auth, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/identities/faceauthentication/face_authentication.go
+++ b/identities/faceauthentication/face_authentication.go
@@ -11,6 +11,7 @@ const (
 	faceAuthenticationsPath = "face-authentications"
 	anonymizePath           = "anonymize"
 	attemptsPath            = "attempts"
+	assetsPath              = "assets"
 )
 
 type CreateFaceAuthenticationRequest struct {
@@ -55,4 +56,18 @@ type FaceAuthenticationAttemptsResponse struct {
 	Skip         int                                  `json:"skip,omitempty"`
 	Limit        int                                  `json:"limit,omitempty"`
 	Data         []FaceAuthenticationAttemptResponse  `json:"data,omitempty"`
+}
+
+type FaceAuthenticationAttemptAsset struct {
+	Type  identities.FaceAuthenticationAttemptAssetType `json:"type,omitempty"`
+	Links identities.AttemptAssetLinks                  `json:"_links,omitempty"`
+}
+
+type FaceAuthenticationAttemptAssetsResponse struct {
+	HttpMetadata common.HttpMetadata
+	TotalCount   int                              `json:"total_count,omitempty"`
+	Skip         int                              `json:"skip,omitempty"`
+	Limit        int                              `json:"limit,omitempty"`
+	Data         []FaceAuthenticationAttemptAsset `json:"data,omitempty"`
+	Links        map[string]common.Link           `json:"_links,omitempty"`
 }

--- a/identities/faceauthentication/face_authentication_fields_test.go
+++ b/identities/faceauthentication/face_authentication_fields_test.go
@@ -1,0 +1,40 @@
+package faceauthentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/identities"
+)
+
+// Verifies the face authentication attempt assets response (FavAttemptAssets)
+// deserializes from the API wire format, including the asset type enum and the
+// nested _links.asset_url HAL link.
+func TestFaceAuthenticationAttemptAssetsResponse_Unmarshal(t *testing.T) {
+	payload := `{
+		"total_count":2,
+		"skip":0,
+		"limit":10,
+		"data":[
+			{"type":"face_image","_links":{"asset_url":{"href":"https://example.com/face-image.jpg"}}},
+			{"type":"face_video","_links":{"asset_url":{"href":"https://example.com/face-video.mp4"}}}
+		],
+		"_links":{"self":{"href":"https://example.com/assets"},"next":{"href":"https://example.com/assets?skip=10"}}
+	}`
+
+	var response FaceAuthenticationAttemptAssetsResponse
+	err := json.Unmarshal([]byte(payload), &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, response.TotalCount)
+	assert.Equal(t, 0, response.Skip)
+	assert.Equal(t, 10, response.Limit)
+	assert.Len(t, response.Data, 2)
+	assert.Equal(t, identities.FaceImageFavAsset, response.Data[0].Type)
+	assert.NotNil(t, response.Data[0].Links.AssetUrl.HRef)
+	assert.Equal(t, "https://example.com/face-image.jpg", *response.Data[0].Links.AssetUrl.HRef)
+	assert.Equal(t, identities.FaceVideoFavAsset, response.Data[1].Type)
+	assert.Contains(t, response.Links, "self")
+}

--- a/identities/identities.go
+++ b/identities/identities.go
@@ -169,3 +169,40 @@ type DocumentDetails struct {
 type FaceImage struct {
 	ImageSignedUrl string `json:"image_signed_url,omitempty"`
 }
+
+// FaceAuthenticationAttemptAssetType is the type of asset captured during a face authentication attempt.
+type FaceAuthenticationAttemptAssetType string
+
+const (
+	FaceImageFavAsset FaceAuthenticationAttemptAssetType = "face_image"
+	FaceVideoFavAsset FaceAuthenticationAttemptAssetType = "face_video"
+)
+
+// IdentityVerificationAttemptAssetType is the type of asset captured during an identity verification attempt.
+type IdentityVerificationAttemptAssetType string
+
+const (
+	FaceImageIdvAsset                    IdentityVerificationAttemptAssetType = "face_image"
+	FaceVideoIdvAsset                    IdentityVerificationAttemptAssetType = "face_video"
+	DocumentFrontImageIdvAsset           IdentityVerificationAttemptAssetType = "document_front_image"
+	DocumentBackImageIdvAsset            IdentityVerificationAttemptAssetType = "document_back_image"
+	DocumentFrontVideoIdvAsset           IdentityVerificationAttemptAssetType = "document_front_video"
+	DocumentBackVideoIdvAsset            IdentityVerificationAttemptAssetType = "document_back_video"
+	DocumentSignatureImageIdvAsset       IdentityVerificationAttemptAssetType = "document_signature_image"
+	SecondaryDocumentFrontImageIdvAsset  IdentityVerificationAttemptAssetType = "secondary_document_front_image"
+	SecondaryDocumentBackImageIdvAsset   IdentityVerificationAttemptAssetType = "secondary_document_back_image"
+	SecondaryDocumentFrontVideoIdvAsset  IdentityVerificationAttemptAssetType = "secondary_document_front_video"
+	SecondaryDocumentBackVideoIdvAsset   IdentityVerificationAttemptAssetType = "secondary_document_back_video"
+	SecondaryDocumentSignatureImageAsset IdentityVerificationAttemptAssetType = "secondary_document_signature_image"
+)
+
+// AttemptAssetsQueryFilter holds the pagination query parameters for retrieving attempt assets.
+type AttemptAssetsQueryFilter struct {
+	Skip  int `url:"skip,omitempty"`
+	Limit int `url:"limit,omitempty"`
+}
+
+// AttemptAssetLinks holds the links related to an attempt asset.
+type AttemptAssetLinks struct {
+	AssetUrl common.Link `json:"asset_url,omitempty"`
+}

--- a/identities/identityverification/client.go
+++ b/identities/identityverification/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/client"
 	"github.com/checkout/checkout-sdk-go/v2/common"
 	"github.com/checkout/checkout-sdk-go/v2/configuration"
+	"github.com/checkout/checkout-sdk-go/v2/identities"
 )
 
 type Client struct {
@@ -165,6 +166,30 @@ func (c *Client) GetIdentityVerificationReportWithContext(ctx context.Context, v
 
 	var response IdentityVerificationReportResponse
 	err = c.apiClient.GetWithContext(ctx, common.BuildPath(identityVerificationsPath, verificationId, reportPath), auth, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetIdentityVerificationAttemptAssets(verificationId, attemptId string, query identities.AttemptAssetsQueryFilter) (*IdentityVerificationAttemptAssetsResponse, error) {
+	return c.GetIdentityVerificationAttemptAssetsWithContext(context.Background(), verificationId, attemptId, query)
+}
+
+func (c *Client) GetIdentityVerificationAttemptAssetsWithContext(ctx context.Context, verificationId, attemptId string, query identities.AttemptAssetsQueryFilter) (*IdentityVerificationAttemptAssetsResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := common.BuildQueryPath(common.BuildPath(identityVerificationsPath, verificationId, attemptsPath, attemptId, assetsPath), query)
+	if err != nil {
+		return nil, err
+	}
+
+	var response IdentityVerificationAttemptAssetsResponse
+	err = c.apiClient.GetWithContext(ctx, url, auth, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/identities/identityverification/identity_verification.go
+++ b/identities/identityverification/identity_verification.go
@@ -13,6 +13,7 @@ const (
 	anonymizePath             = "anonymize"
 	attemptsPath              = "attempts"
 	reportPath                = "pdf-report"
+	assetsPath                = "assets"
 )
 
 type CreateIdentityVerificationRequest struct {
@@ -84,4 +85,18 @@ type IdentityVerificationAttemptsResponse struct {
 type IdentityVerificationReportResponse struct {
 	HttpMetadata common.HttpMetadata
 	SignedUrl    string `json:"signed_url,omitempty"`
+}
+
+type IdentityVerificationAttemptAsset struct {
+	Type  identities.IdentityVerificationAttemptAssetType `json:"type,omitempty"`
+	Links identities.AttemptAssetLinks                    `json:"_links,omitempty"`
+}
+
+type IdentityVerificationAttemptAssetsResponse struct {
+	HttpMetadata common.HttpMetadata
+	TotalCount   int                                `json:"total_count,omitempty"`
+	Skip         int                                `json:"skip,omitempty"`
+	Limit        int                                `json:"limit,omitempty"`
+	Data         []IdentityVerificationAttemptAsset `json:"data,omitempty"`
+	Links        map[string]common.Link             `json:"_links,omitempty"`
 }

--- a/identities/identityverification/identity_verification_fields_test.go
+++ b/identities/identityverification/identity_verification_fields_test.go
@@ -1,0 +1,40 @@
+package identityverification
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/identities"
+)
+
+// Verifies the identity verification attempt assets response (IdvAttemptAssets)
+// deserializes from the API wire format, including the asset type enum and the
+// nested _links.asset_url HAL link.
+func TestIdentityVerificationAttemptAssetsResponse_Unmarshal(t *testing.T) {
+	payload := `{
+		"total_count":2,
+		"skip":0,
+		"limit":10,
+		"data":[
+			{"type":"document_front_image","_links":{"asset_url":{"href":"https://example.com/document-front.jpg"}}},
+			{"type":"face_image","_links":{"asset_url":{"href":"https://example.com/face-image.jpg"}}}
+		],
+		"_links":{"self":{"href":"https://example.com/assets"},"previous":{"href":"https://example.com/assets?skip=0"}}
+	}`
+
+	var response IdentityVerificationAttemptAssetsResponse
+	err := json.Unmarshal([]byte(payload), &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, response.TotalCount)
+	assert.Equal(t, 0, response.Skip)
+	assert.Equal(t, 10, response.Limit)
+	assert.Len(t, response.Data, 2)
+	assert.Equal(t, identities.DocumentFrontImageIdvAsset, response.Data[0].Type)
+	assert.NotNil(t, response.Data[0].Links.AssetUrl.HRef)
+	assert.Equal(t, "https://example.com/document-front.jpg", *response.Data[0].Links.AssetUrl.HRef)
+	assert.Equal(t, identities.FaceImageIdvAsset, response.Data[1].Type)
+	assert.Contains(t, response.Links, "self")
+}

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -606,6 +606,7 @@ type (
 		AffiliateId             string                    `json:"affiliate_id,omitempty"`
 		AffiliateUrl            string                    `json:"affiliate_url,omitempty"`
 		PartnerCode             string                    `json:"partner_code,omitempty"`
+		SchemeTransactionLinkId string                    `json:"scheme_transaction_link_id,omitempty"`
 	}
 
 	ThreeDsEnrollment struct {

--- a/payments/processing_data_test.go
+++ b/payments/processing_data_test.go
@@ -113,3 +113,16 @@ func TestPaymentProcessing_SchemeTransactionLinkIdAbsent(t *testing.T) {
 	assert.Equal(t, "RRN001", processing.RetrievalReferenceNumber)
 	assert.Empty(t, processing.SchemeTransactionLinkId)
 }
+
+// Verifies scheme_transaction_link_id on the request-side ProcessingSettings
+// (PaymentRequestProcessing) serializes to its snake_case wire name and is
+// omitted when unset.
+func TestProcessingSettings_SchemeTransactionLinkId(t *testing.T) {
+	marshalled, err := json.Marshal(ProcessingSettings{SchemeTransactionLinkId: "MTL-001"})
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"scheme_transaction_link_id":"MTL-001"`)
+
+	marshalled, err = json.Marshal(ProcessingSettings{})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "scheme_transaction_link_id")
+}

--- a/test/identities_faceauthentication_test.go
+++ b/test/identities_faceauthentication_test.go
@@ -246,6 +246,49 @@ func TestGetFaceAuthenticationAttempt(t *testing.T) {
 	}
 }
 
+func TestGetFaceAuthenticationAttemptAssets(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+	cases := []struct {
+		name                 string
+		faceAuthenticationId string
+		attemptId            string
+		query                identities.AttemptAssetsQueryFilter
+		checker              func(*faceauthentication.FaceAuthenticationAttemptAssetsResponse, error)
+	}{
+		{
+			name:                 "when face authentication and attempt exist then should return 200",
+			faceAuthenticationId: faceAuthenticationId,
+			attemptId:            faceAuthAttemptId,
+			query:                identities.AttemptAssetsQueryFilter{Skip: 0, Limit: 10},
+			checker: func(response *faceauthentication.FaceAuthenticationAttemptAssetsResponse, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+				assert.NotNil(t, response.Data)
+			},
+		},
+		{
+			name:                 "when face authentication not found then should return error",
+			faceAuthenticationId: "face_auth_not_found",
+			attemptId:            "atm_not_found",
+			query:                identities.AttemptAssetsQueryFilter{},
+			checker: func(response *faceauthentication.FaceAuthenticationAttemptAssetsResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIdentitiesApi().FaceAuthentication
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.GetFaceAuthenticationAttemptAssets(tc.faceAuthenticationId, tc.attemptId, tc.query))
+		})
+	}
+}
+
 // # common methods
 
 func createFaceAuthenticationRequest() faceauthentication.CreateFaceAuthenticationRequest {

--- a/test/identities_identityverification_test.go
+++ b/test/identities_identityverification_test.go
@@ -325,6 +325,49 @@ func TestGetIdentityVerificationReport(t *testing.T) {
 	}
 }
 
+func TestGetIdentityVerificationAttemptAssets(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+	cases := []struct {
+		name           string
+		verificationId string
+		attemptId      string
+		query          identities.AttemptAssetsQueryFilter
+		checker        func(*identityverification.IdentityVerificationAttemptAssetsResponse, error)
+	}{
+		{
+			name:           "when identity verification and attempt exist then should return 200",
+			verificationId: identityVerificationId,
+			attemptId:      idvAttemptId,
+			query:          identities.AttemptAssetsQueryFilter{Skip: 0, Limit: 10},
+			checker: func(response *identityverification.IdentityVerificationAttemptAssetsResponse, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+				assert.NotNil(t, response.Data)
+			},
+		},
+		{
+			name:           "when identity verification not found then should return error",
+			verificationId: "idv_not_found",
+			attemptId:      "atm_not_found",
+			query:          identities.AttemptAssetsQueryFilter{},
+			checker: func(response *identityverification.IdentityVerificationAttemptAssetsResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIdentitiesApi().IdentityVerification
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.GetIdentityVerificationAttemptAssets(tc.verificationId, tc.attemptId, tc.query))
+		})
+	}
+}
+
 // # common methods
 
 func createIdentityVerificationAndAttemptRequest() identityverification.CreateIdentityVerificationAndAttemptRequest {


### PR DESCRIPTION
This pull request introduces new support for retrieving and handling "attempt assets" for both face authentication and identity verification flows, adds corresponding type definitions and enums, and includes thorough serialization and deserialization test coverage. Additionally, it introduces a new field to payment processing settings. The changes are grouped below by theme.

**Face Authentication and Identity Verification Attempt Assets:**

* Added new API client methods in `faceauthentication/client.go` and `identityverification/client.go` to retrieve attempt assets for a given face authentication or identity verification attempt, supporting pagination via a query filter. [[1]](diffhunk://#diff-6cba602c3a51cc3186adcd287918ef8913c4311f3e99c5013e92f5882d3b0ccbR137-R160) [[2]](diffhunk://#diff-966c74ed2774ea92c6c4e43594d68bcda3543f98c781f801b176da363e69bcfcR175-R198)
* Introduced new response types (`FaceAuthenticationAttemptAssetsResponse`, `IdentityVerificationAttemptAssetsResponse`) and asset types/enums to model the returned data, including asset type and HAL links for asset URLs. [[1]](diffhunk://#diff-bcde045d05c9a59c3d5d4c5271407fded6b75ce4998485925a4758ffa8ddb1bcR60-R73) [[2]](diffhunk://#diff-0ad068a66c429a326274b06ce112dc339a890b17bf9360367441d8f73eb4b123R89-R102) [[3]](diffhunk://#diff-a4066d40dbe9950d78b5718d8b5909797ea71c4d661b1ba048a2810b9a52439dR172-R208)
* Added constants for the new API path segment `assets` to support the new endpoints. [[1]](diffhunk://#diff-bcde045d05c9a59c3d5d4c5271407fded6b75ce4998485925a4758ffa8ddb1bcR14) [[2]](diffhunk://#diff-0ad068a66c429a326274b06ce112dc339a890b17bf9360367441d8f73eb4b123R16)
* Implemented and updated tests for both the deserialization of these responses and the API client methods, ensuring correct handling of asset types, links, and error cases. [[1]](diffhunk://#diff-f2c7a5d00ae4a5b2217cb3cfc1df4af8976c16306243b7f1ea4ce436fa312f15R1-R40) [[2]](diffhunk://#diff-01de19c8c8184da2e9faa9a281c308678ae7cf7a36300bc5ab394fa2997f3016R1-R40) [[3]](diffhunk://#diff-3d3b79217bdf21518452aaba65c45d360d3e7a98becc84fcacdd761ee1591b6cR249-R291) [[4]](diffhunk://#diff-0146b6c8fa7545d9bf4f6fefba498b2a08a2f46c91e4c64c7951fd91dee82595R328-R370)

**Payments API:**

* Added the `SchemeTransactionLinkId` field to the `ProcessingSettings` struct, with test coverage to ensure it serializes correctly and is omitted when unset. [[1]](diffhunk://#diff-27713d6983bc85f6078d84b119f33d83ca6c3cda6ce906e87ddb931724e0d287R609) [[2]](diffhunk://#diff-3fa6ff02a0a4bba10c70b98c3a4f47cf849d4ce4a6fc2a6ba2ded7db7a66b005R116-R128)