### PR TITLE
Add recommendation_code to ProcessingData

### DIFF
--- a/payments/payments.go
+++ b/payments/payments.go
@@ -889,6 +889,7 @@ type (
 		PurchaseCountry                  common.Country                   `json:"purchase_country,omitempty"`
 		Locale                           string                           `json:"locale,omitempty"`
 		RetrievalReferenceNumber         string                           `json:"retrieval_reference_number,omitempty"`
+		RecommendationCode               string                           `json:"recommendation_code,omitempty"`
 		PartnerOrderId                   string                           `json:"partner_order_id,omitempty"`
 		PartnerStatus                    string                           `json:"partner_status,omitempty"`
 		PartnerTransactionId             string                           `json:"partner_transaction_id,omitempty"`

--- a/payments/processing_data_test.go
+++ b/payments/processing_data_test.go
@@ -19,6 +19,7 @@ import (
 //   - partner_response_code
 //   - fallback_source_used
 //   - scheme_transaction_link_id (Mastercard Transaction Link Identifier)
+//   - recommendation_code (Mastercard/Visa recommendation code)
 func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 	payload := `{
 		"scheme":"ACCEL",
@@ -29,6 +30,7 @@ func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 		"partner_response_code":"DECLINED",
 		"fallback_source_used":true,
 		"scheme_transaction_link_id":"MTL-XYZ-789",
+		"recommendation_code":"02",
 		"accommodation_data":[{"name":"Grand Hotel"}],
 		"airline_data":[{"ticket":{"number":"045-21351455613"}}]
 	}`
@@ -45,6 +47,7 @@ func TestProcessingData_UnmarshalAllNewFields(t *testing.T) {
 	assert.Equal(t, "DECLINED", data.PartnerResponseCode)
 	assert.True(t, data.FallbackSourceUsed)
 	assert.Equal(t, "MTL-XYZ-789", data.SchemeTransactionLinkId)
+	assert.Equal(t, "02", data.RecommendationCode)
 
 	assert.Len(t, data.AccommodationData, 1)
 	assert.Equal(t, "Grand Hotel", data.AccommodationData[0].Name)
@@ -72,6 +75,7 @@ func TestProcessingData_LeavesNewFieldsZeroWhenAbsent(t *testing.T) {
 	assert.Empty(t, data.PartnerResponseCode)
 	assert.False(t, data.FallbackSourceUsed)
 	assert.Empty(t, data.SchemeTransactionLinkId)
+	assert.Empty(t, data.RecommendationCode)
 	assert.Nil(t, data.AccommodationData)
 	assert.Nil(t, data.AirlineData)
 }


### PR DESCRIPTION
## Summary

Fixes #220.

`payments.ProcessingData` — the `processing` object on `nas.GetPaymentResponse` (Get Payment Details) — did not model `recommendation_code`, even though the API returns it there. The sibling `payments.PaymentProcessing` struct (used for `processing` on the synchronous `nas.PaymentResponse`) already exposes the field, so the value was available after a synchronous payment request but silently dropped when the same payment was read back via Get Payment Details.

This PR adds the field to `ProcessingData`, matching `PaymentProcessing`:

```go
RecommendationCode string `json:"recommendation_code,omitempty"`
```

`recommendation_code` is [documented by Checkout.com](https://www.checkout.com/docs/developer-resources/codes/recommendation-codes) for Mastercard/Visa payments.

## Tests

Extends the existing `ProcessingData` unmarshal tests in `payments/processing_data_test.go` to cover `recommendation_code` — both that it deserializes correctly and that it stays zero-valued when absent — matching the pattern established when the other `processing` fields were aligned with the swagger spec.

## Notes

- The field is placed next to `RetrievalReferenceNumber` to mirror its grouping in `PaymentProcessing`.
- Additive, backwards-compatible change: a new `omitempty` string field on an existing struct.
- `go build ./payments/` passes, `go test ./payments/` passes, and `gofmt` reports no changes.
