### PR TITLE
fix(setups): align confirm response with PaymentSetup and complete fields

### DIFF
--- a/payments/setups/client.go
+++ b/payments/setups/client.go
@@ -99,23 +99,24 @@ func (c *Client) GetPaymentSetupWithContext(ctx context.Context, setupId string)
 }
 
 // ConfirmPaymentSetup confirms a Payment Setup to begin processing the
-// payment request with your chosen payment method option.
+// payment request with your chosen payment method.
 // Beta
 //
 // Confirm a Payment Setup to begin processing the payment request with your
-// chosen payment method option.
-func (c *Client) ConfirmPaymentSetup(setupId string, paymentMethodOptionId string) (*PaymentSetupConfirmResponse, error) {
-	return c.ConfirmPaymentSetupWithContext(context.Background(), setupId, paymentMethodOptionId)
+// chosen payment method. paymentMethodName is the name of the payment method
+// to process the payment with (for example, tabby, klarna, card).
+func (c *Client) ConfirmPaymentSetup(setupId string, paymentMethodName string) (*PaymentSetupResponse, error) {
+	return c.ConfirmPaymentSetupWithContext(context.Background(), setupId, paymentMethodName)
 }
 
-func (c *Client) ConfirmPaymentSetupWithContext(ctx context.Context, setupId string, paymentMethodOptionId string) (*PaymentSetupConfirmResponse, error) {
+func (c *Client) ConfirmPaymentSetupWithContext(ctx context.Context, setupId string, paymentMethodName string) (*PaymentSetupResponse, error) {
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {
 		return nil, err
 	}
 
-	var response PaymentSetupConfirmResponse
-	err = c.apiClient.PostWithContext(ctx, common.BuildPath(PaymentSetupsPath, setupId, ConfirmPath, paymentMethodOptionId), auth, nil, &response, nil)
+	var response PaymentSetupResponse
+	err = c.apiClient.PostWithContext(ctx, common.BuildPath(PaymentSetupsPath, setupId, ConfirmPath, paymentMethodName), auth, nil, &response, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/payments/setups/client_test.go
+++ b/payments/setups/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/configuration"
 	"github.com/checkout/checkout-sdk-go/v2/errors"
 	"github.com/checkout/checkout-sdk-go/v2/mocks"
-	"github.com/checkout/checkout-sdk-go/v2/payments"
 )
 
 func TestCreatePaymentSetup(t *testing.T) {
@@ -261,26 +260,26 @@ func TestGetPaymentSetup(t *testing.T) {
 
 func TestConfirmPaymentSetup(t *testing.T) {
 	var (
-		setupId               = "ps_123456789"
-		paymentMethodOptionId = "pmo_123456789"
-		confirmResponse       = PaymentSetupConfirmResponse{
-			Id:     setupId,
-			Status: payments.Authorized,
+		setupId           = "ps_123456789"
+		paymentMethodName = "card"
+		confirmResponse   = PaymentSetupResponse{
+			Id:        setupId,
+			Reference: "REF-0987-475",
 		}
 	)
 
 	cases := []struct {
-		name                  string
-		setupId               string
-		paymentMethodOptionId string
-		getAuthorization      func(*mock.Mock) mock.Call
-		apiPost               func(*mock.Mock) mock.Call
-		checker               func(*PaymentSetupConfirmResponse, error)
+		name              string
+		setupId           string
+		paymentMethodName string
+		getAuthorization  func(*mock.Mock) mock.Call
+		apiPost           func(*mock.Mock) mock.Call
+		checker           func(*PaymentSetupResponse, error)
 	}{
 		{
-			name:                  "when path parameters are correct then confirm payment setup",
-			setupId:               setupId,
-			paymentMethodOptionId: paymentMethodOptionId,
+			name:              "when path parameters are correct then confirm payment setup",
+			setupId:           setupId,
+			paymentMethodName: paymentMethodName,
 			getAuthorization: func(m *mock.Mock) mock.Call {
 				return *m.On("GetAuthorization", mock.Anything).
 					Return(&configuration.SdkAuthorization{}, nil)
@@ -289,21 +288,21 @@ func TestConfirmPaymentSetup(t *testing.T) {
 				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil).
 					Run(func(args mock.Arguments) {
-						respMapping := args.Get(4).(*PaymentSetupConfirmResponse)
+						respMapping := args.Get(4).(*PaymentSetupResponse)
 						*respMapping = confirmResponse
 					})
 			},
-			checker: func(response *PaymentSetupConfirmResponse, err error) {
+			checker: func(response *PaymentSetupResponse, err error) {
 				assert.Nil(t, err)
 				assert.NotNil(t, response)
 				assert.Equal(t, confirmResponse.Id, response.Id)
-				assert.Equal(t, confirmResponse.Status, response.Status)
+				assert.Equal(t, confirmResponse.Reference, response.Reference)
 			},
 		},
 		{
-			name:                  "when credentials invalid then return error",
-			setupId:               setupId,
-			paymentMethodOptionId: paymentMethodOptionId,
+			name:              "when credentials invalid then return error",
+			setupId:           setupId,
+			paymentMethodName: paymentMethodName,
 			getAuthorization: func(m *mock.Mock) mock.Call {
 				return *m.On("GetAuthorization", mock.Anything).
 					Return(nil, errors.CheckoutAuthorizationError("Invalid authorization"))
@@ -312,7 +311,7 @@ func TestConfirmPaymentSetup(t *testing.T) {
 				return *m.On("PostWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
-			checker: func(response *PaymentSetupConfirmResponse, err error) {
+			checker: func(response *PaymentSetupResponse, err error) {
 				assert.Nil(t, response)
 				assert.NotNil(t, err)
 				chkErr := err.(errors.CheckoutAuthorizationError)
@@ -333,7 +332,7 @@ func TestConfirmPaymentSetup(t *testing.T) {
 			enableTelemetry := true
 			config := configuration.NewConfiguration(credentials, &enableTelemetry, environment, &http.Client{}, nil)
 			client := NewClient(config, apiClient)
-			tc.checker(client.ConfirmPaymentSetup(tc.setupId, tc.paymentMethodOptionId))
+			tc.checker(client.ConfirmPaymentSetup(tc.setupId, tc.paymentMethodName))
 		})
 	}
 }

--- a/payments/setups/setups.go
+++ b/payments/setups/setups.go
@@ -32,6 +32,7 @@ type PaymentSetupRequest struct {
 	Settings                  *PaymentSetupSettings                  `json:"settings,omitempty"`
 	Customer                  *PaymentSetupCustomer                  `json:"customer,omitempty"`
 	Order                     *PaymentSetupOrder                     `json:"order,omitempty"`
+	Billing                   *PaymentSetupBilling                   `json:"billing,omitempty"`
 	Industry                  *PaymentSetupIndustry                  `json:"industry,omitempty"`
 	AccountFundingTransaction *PaymentSetupAccountFundingTransaction `json:"account_funding_transaction,omitempty"`
 	BillingDescriptor         *PaymentSetupBillingDescriptor         `json:"billing_descriptor,omitempty"`
@@ -53,12 +54,18 @@ type PaymentSetupResponse struct {
 	Settings                  *PaymentSetupSettings                  `json:"settings,omitempty"`
 	Customer                  *PaymentSetupCustomer                  `json:"customer,omitempty"`
 	Order                     *PaymentSetupOrder                     `json:"order,omitempty"`
+	Billing                   *PaymentSetupBilling                   `json:"billing,omitempty"`
 	Industry                  *PaymentSetupIndustry                  `json:"industry,omitempty"`
 	AccountFundingTransaction *PaymentSetupAccountFundingTransaction `json:"account_funding_transaction,omitempty"`
 	BillingDescriptor         *PaymentSetupBillingDescriptor         `json:"billing_descriptor,omitempty"`
 	PresentmentDetails        *PaymentSetupPresentmentDetails        `json:"presentment_details,omitempty"`
 	Terminal                  *PaymentSetupTerminal                  `json:"terminal,omitempty"`
 	LatestPayment             map[string]interface{}                 `json:"latest_payment,omitempty"`
+}
+
+// PaymentSetupBilling is the billing details for the payment.
+type PaymentSetupBilling struct {
+	Address *common.Address `json:"address,omitempty"`
 }
 
 // PaymentSetupBillingDescriptor is the billing descriptor for the payment.

--- a/payments/setups/setups.go
+++ b/payments/setups/setups.go
@@ -81,34 +81,6 @@ type PaymentSetupTerminal struct {
 	LocalDateTime *time.Time `json:"local_date_time,omitempty"`
 }
 
-type PaymentSetupConfirmResponse struct {
-	HttpMetadata    common.HttpMetadata
-	Id              string                      `json:"id"`
-	ActionId        string                      `json:"action_id"`
-	Amount          int64                       `json:"amount"`
-	Currency        common.Currency             `json:"currency"`
-	Approved        bool                        `json:"approved"`
-	Status          payments.PaymentStatus      `json:"status"`
-	ResponseCode    string                      `json:"response_code"`
-	ProcessedOn     *time.Time                  `json:"processed_on"`
-	Links           map[string]common.Link      `json:"_links"`
-	AmountRequested int                         `json:"amount_requested,omitempty"`
-	AuthCode        string                      `json:"auth_code,omitempty"`
-	ResponseSummary string                      `json:"response_summary,omitempty"`
-	ExpiresOn       *time.Time                  `json:"expires_on,omitempty"`
-	ThreeDs         *payments.ThreeDsEnrollment `json:"3ds,omitempty"`
-	Risk            *payments.RiskAssessment    `json:"risk,omitempty"`
-	Source          *PaymentSetupSource         `json:"source,omitempty"`
-	Customer        *common.CustomerResponse    `json:"customer,omitempty"`
-	Balances        *PaymentSetupBalances       `json:"balances,omitempty"`
-	Reference       string                      `json:"reference,omitempty"`
-	Subscription    *PaymentSetupSubscription   `json:"subscription,omitempty"`
-	Processing      *payments.PaymentProcessing `json:"processing,omitempty"`
-	Eci             string                      `json:"eci,omitempty"`
-	SchemeId        string                      `json:"scheme_id,omitempty"`
-	Retry           *PaymentSetupRetry          `json:"retry,omitempty"`
-}
-
 // ===== Customer Structs =====
 
 type PaymentSetupCustomer struct {
@@ -435,45 +407,6 @@ type AirlineData struct {
 	Ticket           *payments.Ticket            `json:"ticket,omitempty"`
 	Passengers       []payments.Passenger        `json:"passengers,omitempty"`
 	FlightLegDetails []payments.FlightLegDetails `json:"flight_leg_details,omitempty"`
-}
-
-type PaymentSetupSource struct {
-	Type                    string              `json:"type,omitempty"`
-	Id                      string              `json:"id,omitempty"`
-	BillingAddress          *common.Address     `json:"billing_address,omitempty"`
-	Phone                   *common.Phone       `json:"phone,omitempty"`
-	Scheme                  string              `json:"scheme,omitempty"`
-	Last4                   string              `json:"last4,omitempty"`
-	Fingerprint             string              `json:"fingerprint,omitempty"`
-	Bin                     string              `json:"bin,omitempty"`
-	CardType                common.CardType     `json:"card_type,omitempty"`
-	CardCategory            common.CardCategory `json:"card_category,omitempty"`
-	Issuer                  string              `json:"issuer,omitempty"`
-	IssuerCountry           common.Country      `json:"issuer_country,omitempty"`
-	ProductType             string              `json:"product_type,omitempty"`
-	AvsCheck                string              `json:"avs_check,omitempty"`
-	CvvCheck                string              `json:"cvv_check,omitempty"`
-	PaymentAccountReference string              `json:"payment_account_reference,omitempty"`
-}
-
-type PaymentSetupBalances struct {
-	TotalAuthorized    int `json:"total_authorized,omitempty"`
-	TotalVoided        int `json:"total_voided,omitempty"`
-	AvailableToVoid    int `json:"available_to_void,omitempty"`
-	TotalCaptured      int `json:"total_captured,omitempty"`
-	AvailableToCapture int `json:"available_to_capture,omitempty"`
-	TotalRefunded      int `json:"total_refunded,omitempty"`
-	AvailableToRefund  int `json:"available_to_refund,omitempty"`
-}
-
-type PaymentSetupSubscription struct {
-	Id string `json:"id,omitempty"`
-}
-
-type PaymentSetupRetry struct {
-	MaxAttempts   int        `json:"max_attempts,omitempty"`
-	EndsOn        *time.Time `json:"ends_on,omitempty"`
-	NextAttemptOn *time.Time `json:"next_attempt_on,omitempty"`
 }
 
 type AccountFundingTransactionPurpose string

--- a/test/payment_setups_test.go
+++ b/test/payment_setups_test.go
@@ -186,7 +186,7 @@ func TestGetPaymentSetup(t *testing.T) {
 }
 
 func TestConfirmPaymentSetup(t *testing.T) {
-	t.Skip("Confirmation requires a valid payment method option ID from a real setup")
+	t.Skip("Confirmation requires a valid payment method name from a real setup")
 
 	// First create a payment setup
 	createResponse, err := DefaultApi().PaymentSetups.CreatePaymentSetup(paymentSetupRequest)
@@ -194,27 +194,24 @@ func TestConfirmPaymentSetup(t *testing.T) {
 	assert.NotNil(t, createResponse)
 	setupId := createResponse.Id
 
-	// Get a valid payment method option ID from the setup (would need real API response)
-	paymentMethodOptionId := "pmo_real_option_id"
+	// The name of the payment method to process the payment with (for example, tabby, klarna, card)
+	paymentMethodName := "card"
 
 	cases := []struct {
-		name                  string
-		setupId               string
-		paymentMethodOptionId string
-		checker               func(response *setups.PaymentSetupConfirmResponse, err error)
+		name              string
+		setupId           string
+		paymentMethodName string
+		checker           func(response *setups.PaymentSetupResponse, err error)
 	}{
 		{
-			name:                  "when setup id and option id are valid then confirm payment setup",
-			setupId:               setupId,
-			paymentMethodOptionId: paymentMethodOptionId,
-			checker: func(response *setups.PaymentSetupConfirmResponse, err error) {
+			name:              "when setup id and payment method name are valid then confirm payment setup",
+			setupId:           setupId,
+			paymentMethodName: paymentMethodName,
+			checker: func(response *setups.PaymentSetupResponse, err error) {
 				assert.Nil(t, err)
 				assert.NotNil(t, response)
 				assert.Equal(t, 200, response.HttpMetadata.StatusCode)
 				assert.Equal(t, setupId, response.Id)
-				assert.NotEmpty(t, response.ActionId)
-				assert.NotNil(t, response.Status)
-				assert.NotNil(t, response.Source)
 			},
 		},
 	}
@@ -223,7 +220,7 @@ func TestConfirmPaymentSetup(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.checker(client.ConfirmPaymentSetup(tc.setupId, tc.paymentMethodOptionId))
+			tc.checker(client.ConfirmPaymentSetup(tc.setupId, tc.paymentMethodName))
 		})
 	}
 }
@@ -251,9 +248,9 @@ func TestPaymentSetupFullWorkflow(t *testing.T) {
 	assert.NotNil(t, updateResponse)
 	assert.Equal(t, updatePaymentSetupRequest.Amount, updateResponse.Amount)
 
-	// 4. Confirm payment setup (requires real payment method option)
-	paymentMethodOptionId := "pmo_real_option_from_previous_steps"
-	confirmResponse, err := client.ConfirmPaymentSetup(setupId, paymentMethodOptionId)
+	// 4. Confirm payment setup (requires a real payment method name)
+	paymentMethodName := "card"
+	confirmResponse, err := client.ConfirmPaymentSetup(setupId, paymentMethodName)
 	assert.Nil(t, err)
 	assert.NotNil(t, confirmResponse)
 }


### PR DESCRIPTION
## Problem

Reported by a merchant (in the Java SDK, same root cause here): the payment setup confirm response referenced models from the payments (postpayments) namespace instead of the payment-setups models, breaking onboarding because the shapes differ (e.g. `customer.email` is a nested object in setups but a plain string in the payments customer).

## Root cause

The confirm endpoint `POST /payments/setups/{id}/confirm/{payment_method_name}` returns the `PaymentSetup` schema — the same as create/get. But `ConfirmPaymentSetup` returned a distinct payment-style `PaymentSetupConfirmResponse` (referencing `payments.PaymentStatus`, `ThreeDsEnrollment`, `RiskAssessment`, `PaymentProcessing`, `common.CustomerResponse`).

## Changes

- **`ConfirmPaymentSetup` now returns `*PaymentSetupResponse`** (same as create/get).
- **Removed** the orphaned `PaymentSetupConfirmResponse` and its helper structs (`PaymentSetupSource`, `PaymentSetupBalances`, `PaymentSetupSubscription`, `PaymentSetupRetry`).
- **Renamed** the confirm argument `paymentMethodOptionId` → `paymentMethodName` per the spec.
- **Added the missing `billing` field** (`PaymentSetupBilling` with an address) to `PaymentSetupRequest` and `PaymentSetupResponse` — it is in the schema and the other SDKs but was absent here.

## Verification

- `go build ./...` and `go vet ./payments/setups/...` — clean.
- Note: the test binaries could not be executed in this environment due to a Go toolchain arch mismatch (amd64 under arm64, `dyld missing LC_UUID`), which affects all packages, not this change.