### PR TITLE
Correct PaymentIp deprecation message to reference risk.device.network

### DIFF
--- a/payments/hosted/hosted.go
+++ b/payments/hosted/hosted.go
@@ -48,7 +48,7 @@ type (
 		FailureUrl                 string                                   `json:"failure_url,omitempty"`
 		Amount                     int                                      `json:"amount,omitempty"`
 		PaymentType                payments.PaymentType                     `json:"payment_type,omitempty,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp                  string                                   `json:"payment_ip,omitempty"`
 		BillingDescriptor          *payments.BillingDescriptor              `json:"billing_descriptor,omitempty"`
 		Reference                  string                                   `json:"reference,omitempty"`

--- a/payments/links/links.go
+++ b/payments/links/links.go
@@ -44,7 +44,7 @@ type (
 		Currency                   common.Currency                          `json:"currency,omitempty"`
 		Billing                    *payments.BillingInformation             `json:"billing,omitempty"`
 		PaymentType                payments.PaymentType                     `json:"payment_type,omitempty,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp                  string                                   `json:"payment_ip,omitempty"`
 		BillingDescriptor          *payments.BillingDescriptor              `json:"billing_descriptor,omitempty"`
 		Reference                  string                                   `json:"reference,omitempty"`

--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -166,7 +166,7 @@ type (
 		Risk                 *payments.RiskRequest         `json:"risk,omitempty"`
 		SuccessUrl           string                        `json:"success_url,omitempty"`
 		FailureUrl           string                        `json:"failure_url,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp         string                        `json:"payment_ip,omitempty"`
 		Sender            Sender                        `json:"sender,omitempty"`
 		Recipient         *payments.PaymentRecipient    `json:"recipient,omitempty"`
@@ -289,7 +289,7 @@ type (
 		Customer                 *common.CustomerResponse        `json:"customer,omitempty"`
 		BillingDescriptor        *payments.BillingDescriptor     `json:"billing_descriptor,omitempty"`
 		ShippingDetails *payments.ShippingDetails `json:"shipping,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp         string                  `json:"payment_ip,omitempty"`
 		Marketplace       *common.MarketplaceData `json:"marketplace,omitempty"`
 		AmountAllocations        []common.AmountAllocations      `json:"amount_allocations,omitempty"`


### PR DESCRIPTION
## What

Corrects the deprecation message on the four `PaymentIp` fields (NAS `PaymentRequest` and `GetPaymentResponse`, Hosted Payments, Payment Links) from:

```go
// Deprecated: Use customer.email instead.
```

to:

```go
// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
```

## Why

The current message, introduced in the v2.3.0 general SDK review (#207), points users at `customer.email` as the replacement for `payment_ip`, which appears to be a mix-up — an email address can't replace a customer IP used for risk scoring. Checkout's other official SDKs carry the intended guidance for the same field:

- **checkout-sdk-java** `PaymentRequest.java`: `@deprecated Deprecated in the API on 2025-03-11. Use {@code risk.device.network.ipv4} or {@code risk.device.network.ipv6} instead.`
- **checkout-sdk-net** `PaymentRequest.cs`: `[Obsolete("Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.", false)]`
- **checkout-sdk-php** `PaymentRequest.php`: `Obsolete - Use risk.device.network.ipv4 or risk.device.network.ipv6 instead`

This matters in practice because Go tooling surfaces the message verbatim: `staticcheck`/`golangci-lint` report `SA1019: req.PaymentIp is deprecated: Use customer.email instead.`, which sends integrators chasing the wrong field.

Comment-only change; no behavior or API surface affected.