### PR TITLE
feat(identities): add Address Document Verification (Adv) endpoints

### DIFF
--- a/identities/addressdocumentverification/address_document_verification.go
+++ b/identities/addressdocumentverification/address_document_verification.go
@@ -1,0 +1,87 @@
+package addressdocumentverification
+
+import (
+	"time"
+
+	"github.com/checkout/checkout-sdk-go/v2/common"
+	"github.com/checkout/checkout-sdk-go/v2/identities"
+)
+
+const (
+	addressDocumentVerificationsPath = "address-document-verifications"
+	anonymizePath                    = "anonymize"
+	attemptsPath                     = "attempts"
+	reportPath                       = "pdf-report"
+)
+
+type CreateAddressDocumentVerificationRequest struct {
+	ApplicantId   string                   `json:"applicant_id"`
+	UserJourneyId string                   `json:"user_journey_id"`
+	DeclaredData  *identities.DeclaredData `json:"declared_data,omitempty"`
+}
+
+type CreateAddressDocumentVerificationAttemptRequest struct {
+	Document string `json:"document"`
+}
+
+// Address is the address extracted from the document.
+type Address struct {
+	AddressLine1 string `json:"address_line1,omitempty"`
+	AddressLine2 string `json:"address_line2,omitempty"`
+	City         string `json:"city,omitempty"`
+	State        string `json:"state,omitempty"`
+	Zip          string `json:"zip,omitempty"`
+	Country      string `json:"country,omitempty"`
+}
+
+// AddressDocumentResult is the result of the address document check.
+type AddressDocumentResult struct {
+	DocumentType string   `json:"document_type,omitempty"`
+	Issuer       string   `json:"issuer,omitempty"`
+	FullNames    []string `json:"full_names,omitempty"`
+	IssueDate    string   `json:"issue_date,omitempty"`
+	Address      *Address `json:"address,omitempty"`
+}
+
+// Links holds the HAL links related to the resource (self and, for verifications, applicant).
+type Links struct {
+	Self      *common.Link `json:"self,omitempty"`
+	Applicant *common.Link `json:"applicant,omitempty"`
+}
+
+// addressDocumentVerificationBase holds fields common to all response types.
+type addressDocumentVerificationBase struct {
+	HttpMetadata  common.HttpMetadata
+	Id            string                    `json:"id,omitempty"`
+	CreatedOn     *time.Time                `json:"created_on,omitempty"`
+	ModifiedOn    *time.Time                `json:"modified_on,omitempty"`
+	ResponseCodes []identities.ResponseCode `json:"response_codes,omitempty"`
+	Links         *Links                    `json:"_links,omitempty"`
+}
+
+type AddressDocumentVerificationResponse struct {
+	addressDocumentVerificationBase
+	UserJourneyId   string                                       `json:"user_journey_id,omitempty"`
+	ApplicantId     string                                       `json:"applicant_id,omitempty"`
+	Status          identities.AddressDocumentVerificationStatus `json:"status,omitempty"`
+	AddressDocument *AddressDocumentResult                       `json:"address_document,omitempty"`
+}
+
+type AddressDocumentVerificationAttemptResponse struct {
+	addressDocumentVerificationBase
+	Status identities.AddressDocumentVerificationAttemptStatus `json:"status,omitempty"`
+}
+
+type AddressDocumentVerificationAttemptsResponse struct {
+	HttpMetadata common.HttpMetadata
+	TotalCount   int                                          `json:"total_count,omitempty"`
+	Skip         int                                          `json:"skip,omitempty"`
+	Limit        int                                          `json:"limit,omitempty"`
+	Data         []AddressDocumentVerificationAttemptResponse `json:"data,omitempty"`
+	Links        *Links                                       `json:"_links,omitempty"`
+}
+
+type AddressDocumentVerificationReportResponse struct {
+	HttpMetadata common.HttpMetadata
+	SignedUrl    string `json:"signed_url,omitempty"`
+}

--- a/identities/addressdocumentverification/client.go
+++ b/identities/addressdocumentverification/client.go
@@ -1,0 +1,154 @@
+package addressdocumentverification
+
+import (
+	"context"
+
+	"github.com/checkout/checkout-sdk-go/v2/client"
+	"github.com/checkout/checkout-sdk-go/v2/common"
+	"github.com/checkout/checkout-sdk-go/v2/configuration"
+)
+
+type Client struct {
+	configuration *configuration.Configuration
+	apiClient     client.HttpClient
+}
+
+func NewClient(configuration *configuration.Configuration, apiClient client.HttpClient) *Client {
+	return &Client{
+		configuration: configuration,
+		apiClient:     apiClient,
+	}
+}
+
+func (c *Client) CreateAddressDocumentVerification(request CreateAddressDocumentVerificationRequest) (*AddressDocumentVerificationResponse, error) {
+	return c.CreateAddressDocumentVerificationWithContext(context.Background(), request)
+}
+
+func (c *Client) CreateAddressDocumentVerificationWithContext(ctx context.Context, request CreateAddressDocumentVerificationRequest) (*AddressDocumentVerificationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationResponse
+	err = c.apiClient.PostWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath), auth, request, &response, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetAddressDocumentVerification(verificationId string) (*AddressDocumentVerificationResponse, error) {
+	return c.GetAddressDocumentVerificationWithContext(context.Background(), verificationId)
+}
+
+func (c *Client) GetAddressDocumentVerificationWithContext(ctx context.Context, verificationId string) (*AddressDocumentVerificationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationResponse
+	err = c.apiClient.GetWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId), auth, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) AnonymizeAddressDocumentVerification(verificationId string) (*AddressDocumentVerificationResponse, error) {
+	return c.AnonymizeAddressDocumentVerificationWithContext(context.Background(), verificationId)
+}
+
+func (c *Client) AnonymizeAddressDocumentVerificationWithContext(ctx context.Context, verificationId string) (*AddressDocumentVerificationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationResponse
+	err = c.apiClient.PostWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId, anonymizePath), auth, nil, &response, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) CreateAddressDocumentVerificationAttempt(verificationId string, request CreateAddressDocumentVerificationAttemptRequest) (*AddressDocumentVerificationAttemptResponse, error) {
+	return c.CreateAddressDocumentVerificationAttemptWithContext(context.Background(), verificationId, request)
+}
+
+func (c *Client) CreateAddressDocumentVerificationAttemptWithContext(ctx context.Context, verificationId string, request CreateAddressDocumentVerificationAttemptRequest) (*AddressDocumentVerificationAttemptResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationAttemptResponse
+	err = c.apiClient.PostWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId, attemptsPath), auth, request, &response, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetAddressDocumentVerificationAttempts(verificationId string) (*AddressDocumentVerificationAttemptsResponse, error) {
+	return c.GetAddressDocumentVerificationAttemptsWithContext(context.Background(), verificationId)
+}
+
+func (c *Client) GetAddressDocumentVerificationAttemptsWithContext(ctx context.Context, verificationId string) (*AddressDocumentVerificationAttemptsResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationAttemptsResponse
+	err = c.apiClient.GetWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId, attemptsPath), auth, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetAddressDocumentVerificationAttempt(verificationId, attemptId string) (*AddressDocumentVerificationAttemptResponse, error) {
+	return c.GetAddressDocumentVerificationAttemptWithContext(context.Background(), verificationId, attemptId)
+}
+
+func (c *Client) GetAddressDocumentVerificationAttemptWithContext(ctx context.Context, verificationId, attemptId string) (*AddressDocumentVerificationAttemptResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationAttemptResponse
+	err = c.apiClient.GetWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId, attemptsPath, attemptId), auth, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) GetAddressDocumentVerificationReport(verificationId string) (*AddressDocumentVerificationReportResponse, error) {
+	return c.GetAddressDocumentVerificationReportWithContext(context.Background(), verificationId)
+}
+
+func (c *Client) GetAddressDocumentVerificationReportWithContext(ctx context.Context, verificationId string) (*AddressDocumentVerificationReportResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AddressDocumentVerificationReportResponse
+	err = c.apiClient.GetWithContext(ctx, common.BuildPath(addressDocumentVerificationsPath, verificationId, reportPath), auth, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/identities/identities.go
+++ b/identities/identities.go
@@ -62,6 +62,29 @@ const (
 	IddvAttemptTerminated              IdDocumentVerificationAttemptStatus = "terminated"
 )
 
+type AddressDocumentVerificationStatus string
+
+const (
+	AdvCreated                 AddressDocumentVerificationStatus = "created"
+	AdvQualityChecksInProgress AddressDocumentVerificationStatus = "quality_checks_in_progress"
+	AdvChecksInProgress        AddressDocumentVerificationStatus = "checks_in_progress"
+	AdvApproved                AddressDocumentVerificationStatus = "approved"
+	AdvDeclined                AddressDocumentVerificationStatus = "declined"
+	AdvRetryRequired           AddressDocumentVerificationStatus = "retry_required"
+	AdvInconclusive            AddressDocumentVerificationStatus = "inconclusive"
+)
+
+type AddressDocumentVerificationAttemptStatus string
+
+const (
+	AdvAttemptChecksInProgress        AddressDocumentVerificationAttemptStatus = "checks_in_progress"
+	AdvAttemptChecksInconclusive      AddressDocumentVerificationAttemptStatus = "checks_inconclusive"
+	AdvAttemptCompleted               AddressDocumentVerificationAttemptStatus = "completed"
+	AdvAttemptQualityChecksAborted    AddressDocumentVerificationAttemptStatus = "quality_checks_aborted"
+	AdvAttemptQualityChecksInProgress AddressDocumentVerificationAttemptStatus = "quality_checks_in_progress"
+	AdvAttemptTerminated              AddressDocumentVerificationAttemptStatus = "terminated"
+)
+
 type IdentityVerificationStatus string
 
 const (

--- a/nas/checkout_api.go
+++ b/nas/checkout_api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/financial"
 	"github.com/checkout/checkout-sdk-go/v2/forex"
 	"github.com/checkout/checkout-sdk-go/v2/forward"
+	"github.com/checkout/checkout-sdk-go/v2/identities/addressdocumentverification"
 	"github.com/checkout/checkout-sdk-go/v2/identities/amlscreening"
 	"github.com/checkout/checkout-sdk-go/v2/identities/applicants"
 	"github.com/checkout/checkout-sdk-go/v2/identities/faceauthentication"
@@ -44,40 +45,41 @@ import (
 )
 
 type Api struct {
-	Accounts                 *accounts.Client
-	Balances                 *balances.Client
-	Customers                *customers.Client
-	Disputes                 *disputes.Client
-	Financial                *financial.Client
-	Forex                    *forex.Client
-	Hosted                   *hosted.Client
-	Instruments              *instruments.Client
-	Links                    *links.Client
-	Metadata                 *metadata.Client
-	Payments                 *payments.Client
-	Sessions                 *sessions.Client
-	Tokens                   *tokens.Client
-	Transfers                *transfers.Client
-	WorkFlows                *workflows.Client
-	Reports                  *reports.Client
-	Issuing                  *issuing.Client
-	CardholderTokens         *cardholdertokens.Client
-	Contexts                 *contexts.Client
-	PaymentSessions          *payment_sessions.Client
-	PaymentSetups            *setups.Client
-	Forward                  *forward.Client
-	ApplePay                 *applepay.Client
-	GooglePay                *googlepay.Client
-	NetworkTokens            *networktokens.Client
-	StandaloneAccountUpdater *standaloneaccountupdater.Client
-	AgenticCommerce          *agenticcommerce.Client
-	ComplianceRequests       *compliancerequests.Client
-	PaymentMethods           *paymentmethods.Client
-	AmlScreening             *amlscreening.Client
-	Applicants               *applicants.Client
-	FaceAuthentication       *faceauthentication.Client
-	IdDocumentVerification   *iddocumentverification.Client
-	IdentityVerification     *identityverification.Client
+	Accounts                    *accounts.Client
+	Balances                    *balances.Client
+	Customers                   *customers.Client
+	Disputes                    *disputes.Client
+	Financial                   *financial.Client
+	Forex                       *forex.Client
+	Hosted                      *hosted.Client
+	Instruments                 *instruments.Client
+	Links                       *links.Client
+	Metadata                    *metadata.Client
+	Payments                    *payments.Client
+	Sessions                    *sessions.Client
+	Tokens                      *tokens.Client
+	Transfers                   *transfers.Client
+	WorkFlows                   *workflows.Client
+	Reports                     *reports.Client
+	Issuing                     *issuing.Client
+	CardholderTokens            *cardholdertokens.Client
+	Contexts                    *contexts.Client
+	PaymentSessions             *payment_sessions.Client
+	PaymentSetups               *setups.Client
+	Forward                     *forward.Client
+	ApplePay                    *applepay.Client
+	GooglePay                   *googlepay.Client
+	NetworkTokens               *networktokens.Client
+	StandaloneAccountUpdater    *standaloneaccountupdater.Client
+	AgenticCommerce             *agenticcommerce.Client
+	ComplianceRequests          *compliancerequests.Client
+	PaymentMethods              *paymentmethods.Client
+	AmlScreening                *amlscreening.Client
+	Applicants                  *applicants.Client
+	FaceAuthentication          *faceauthentication.Client
+	IdDocumentVerification      *iddocumentverification.Client
+	AddressDocumentVerification *addressdocumentverification.Client
+	IdentityVerification        *identityverification.Client
 
 	Ideal  *ideal.Client
 	Klarna *klarna.Client
@@ -124,6 +126,7 @@ func CheckoutApi(configuration *configuration.Configuration) *Api {
 	api.Applicants = applicants.NewClient(configuration, identityClient)
 	api.FaceAuthentication = faceauthentication.NewClient(configuration, identityClient)
 	api.IdDocumentVerification = iddocumentverification.NewClient(configuration, identityClient)
+	api.AddressDocumentVerification = addressdocumentverification.NewClient(configuration, identityClient)
 	api.IdentityVerification = identityverification.NewClient(configuration, identityClient)
 
 	api.Ideal = ideal.NewClient(configuration, apiClient)

--- a/test/identities_addressdocumentverification_test.go
+++ b/test/identities_addressdocumentverification_test.go
@@ -1,0 +1,114 @@
+package test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/errors"
+	"github.com/checkout/checkout-sdk-go/v2/identities"
+	addressdocumentverification "github.com/checkout/checkout-sdk-go/v2/identities/addressdocumentverification"
+)
+
+func createAddressDocumentVerificationRequest() addressdocumentverification.CreateAddressDocumentVerificationRequest {
+	return addressdocumentverification.CreateAddressDocumentVerificationRequest{
+		ApplicantId:   "aplt_tkoi5db4hryu5cei5vwoabr7we",
+		UserJourneyId: "usj_tkoi5db4hryu5cei5vwoabr7we",
+		DeclaredData: &identities.DeclaredData{
+			Name: "Hannah Bret",
+		},
+	}
+}
+
+func TestCreateAddressDocumentVerification(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+	cases := []struct {
+		name    string
+		request addressdocumentverification.CreateAddressDocumentVerificationRequest
+		checker func(*addressdocumentverification.AddressDocumentVerificationResponse, error)
+	}{
+		{
+			name:    "when request is valid then should return 201",
+			request: createAddressDocumentVerificationRequest(),
+			checker: func(response *addressdocumentverification.AddressDocumentVerificationResponse, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusCreated, response.HttpMetadata.StatusCode)
+				assert.NotEmpty(t, response.Id)
+			},
+		},
+		{
+			name: "when applicant not found then should return error",
+			request: addressdocumentverification.CreateAddressDocumentVerificationRequest{
+				ApplicantId:   "aplt_not_found",
+				UserJourneyId: "usj_test",
+			},
+			checker: func(response *addressdocumentverification.AddressDocumentVerificationResponse, err error) {
+				assert.NotNil(t, err)
+				assert.Nil(t, response)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusNotFound, chkErr.StatusCode)
+			},
+		},
+	}
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.checker(client.CreateAddressDocumentVerification(tc.request))
+		})
+	}
+}
+
+func TestGetAddressDocumentVerification(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	response, err := client.GetAddressDocumentVerification("adv_tkoi5db4hryu5cei5vwoabr7we")
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+}
+
+func TestAnonymizeAddressDocumentVerification(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	_, err := client.AnonymizeAddressDocumentVerification("adv_tkoi5db4hryu5cei5vwoabr7we")
+	assert.Nil(t, err)
+}
+
+func TestCreateAddressDocumentVerificationAttempt(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	request := addressdocumentverification.CreateAddressDocumentVerificationAttemptRequest{
+		Document: "base64-encoded-document-image-data",
+	}
+	_, err := client.CreateAddressDocumentVerificationAttempt("adv_tkoi5db4hryu5cei5vwoabr7we", request)
+	assert.Nil(t, err)
+}
+
+func TestGetAddressDocumentVerificationAttempts(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	_, err := client.GetAddressDocumentVerificationAttempts("adv_tkoi5db4hryu5cei5vwoabr7we")
+	assert.Nil(t, err)
+}
+
+func TestGetAddressDocumentVerificationAttempt(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	_, err := client.GetAddressDocumentVerificationAttempt("adv_tkoi5db4hryu5cei5vwoabr7we", "adva_tkoi5db4hryu5cei5vwoabr7we")
+	assert.Nil(t, err)
+}
+
+func TestGetAddressDocumentVerificationReport(t *testing.T) {
+	t.Skip("Avoid creating identity resources all the time")
+
+	client := buildIdentitiesApi().AddressDocumentVerification
+	_, err := client.GetAddressDocumentVerificationReport("adv_tkoi5db4hryu5cei5vwoabr7we")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
## Summary

Adds the new **Address Document Verification (Adv)** API family introduced in the Checkout.com swagger on 2026-07-16 (INT-1665). This mirrors the existing ID Document Verification client and reuses the `identity-verification` OAuth scope (no new scope).

## Changes

New `AddressDocumentVerification` client exposing the 7 endpoints, plus request/response models and status enums, wired into the SDK entry point next to `IdDocumentVerification`:

- `POST /address-document-verifications` — create
- `GET  /address-document-verifications/{id}` — retrieve
- `POST /address-document-verifications/{id}/anonymize` — anonymize
- `POST /address-document-verifications/{id}/attempts` — create attempt
- `GET  /address-document-verifications/{id}/attempts` — list attempts
- `GET  /address-document-verifications/{id}/attempts/{attemptId}` — get attempt
- `GET  /address-document-verifications/{id}/pdf-report` — PDF report

Request model: `applicant_id`, `user_journey_id`, `declared_data`. Attempt request: `document`. Responses cover `AdvVerificationStatuses` / `AdvAttemptStates`, `response_codes`, `_links` and the extracted `address_document` result.

## API Reference

Swagger schemas: `AdvAddressDocumentVerification*`, `AdvAttempt*`, `AdvAddress`, `AdvAddressDocumentResult`, `AdvVerificationStatuses`, `AdvAttemptStates`.

## Tests

Unit tests covering all 7 endpoints; integration tests scaffolded (skipped, require sandbox entitlement). Build + tests green locally.
