### PR TITLE
Correct PaymentIp deprecation message to reference risk.device.network

### DIFF
--- a/payments/hosted/hosted.go
+++ b/payments/hosted/hosted.go
@@ -48,7 +48,7 @@ type (
 		FailureUrl  string                       `json:"failure_url,omitempty"`
 		Amount      int                          `json:"amount,omitempty"`
 		PaymentType payments.PaymentType         `json:"payment_type,omitempty,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp                  string                                   `json:"payment_ip,omitempty"`
 		BillingDescriptor          *payments.BillingDescriptor              `json:"billing_descriptor,omitempty"`
 		Reference                  string                                   `json:"reference,omitempty"`

--- a/payments/links/links.go
+++ b/payments/links/links.go
@@ -44,7 +44,7 @@ type (
 		Currency    common.Currency              `json:"currency,omitempty"`
 		Billing     *payments.BillingInformation `json:"billing,omitempty"`
 		PaymentType payments.PaymentType         `json:"payment_type,omitempty,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp                  string                                   `json:"payment_ip,omitempty"`
 		BillingDescriptor          *payments.BillingDescriptor              `json:"billing_descriptor,omitempty"`
 		Reference                  string                                   `json:"reference,omitempty"`

--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -166,7 +166,7 @@ type (
 		Risk                 *payments.RiskRequest       `json:"risk,omitempty"`
 		SuccessUrl           string                      `json:"success_url,omitempty"`
 		FailureUrl           string                      `json:"failure_url,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp         string                        `json:"payment_ip,omitempty"`
 		Sender            Sender                        `json:"sender,omitempty"`
 		Recipient         *payments.PaymentRecipient    `json:"recipient,omitempty"`
@@ -289,7 +289,7 @@ type (
 		Customer          *common.CustomerResponse    `json:"customer,omitempty"`
 		BillingDescriptor *payments.BillingDescriptor `json:"billing_descriptor,omitempty"`
 		ShippingDetails   *payments.ShippingDetails   `json:"shipping,omitempty"`
-		// Deprecated: Use customer.email instead.
+		// Deprecated: Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.
 		PaymentIp                string                          `json:"payment_ip,omitempty"`
 		Marketplace              *common.MarketplaceData         `json:"marketplace,omitempty"`
 		AmountAllocations        []common.AmountAllocations      `json:"amount_allocations,omitempty"`


### PR DESCRIPTION
Rebased version of #224 (by @justinadkins) onto current `master` (2.7.0), resolving the conflicts from the v2.7.0 struct reformatting. Original authorship preserved on the commit.

Comment-only change: corrects the deprecation message on the four `PaymentIp` fields (NAS `PaymentRequest`/`GetPaymentResponse`, Hosted Payments, Payment Links) from `Use customer.email instead.` to `Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.`, aligning with the Java/.NET/PHP SDKs.

Closes #224.