### PR TITLE
feature/INT-1667 - ChallengeIndicator/SessionChallengeIndicator enum alignment

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -145,9 +145,9 @@ const (
 type ThreeDsMethodCompletion string
 
 const (
-	Y ThreeDsMethodCompletion = "y"
-	N ThreeDsMethodCompletion = "n"
-	U ThreeDsMethodCompletion = "u"
+	Y ThreeDsMethodCompletion = "Y"
+	N ThreeDsMethodCompletion = "N"
+	U ThreeDsMethodCompletion = "U"
 )
 
 type AccountNameInquiryType string

--- a/sessions/challenge_indicator_test.go
+++ b/sessions/challenge_indicator_test.go
@@ -1,0 +1,118 @@
+package sessions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/common"
+)
+
+// sessionChallengeIndicatorValues are the nine values accepted by
+// SessionRequest.challenge_indicator, per the API Reference ChallengeIndicator schema, in spec order.
+var sessionChallengeIndicatorValues = []SessionChallengeIndicator{
+	SessionChallengeNoPreference,
+	SessionChallengeNoChallengeRequested,
+	SessionChallengeRequested,
+	SessionChallengeRequestedMandate,
+	SessionChallengeLowValue,
+	SessionChallengeTrustedListing,
+	SessionChallengeTrustedListingPrompt,
+	SessionChallengeTransactionRiskAssessment,
+	SessionChallengeDataShare,
+}
+
+var sessionChallengeIndicatorWireValues = []string{
+	"no_preference",
+	"no_challenge_requested",
+	"challenge_requested",
+	"challenge_requested_mandate",
+	"low_value",
+	"trusted_listing",
+	"trusted_listing_prompt",
+	"transaction_risk_assessment",
+	"data_share",
+}
+
+// paymentChallengeIndicatorWireValues are the four values accepted by the 3ds.challenge_indicator
+// field on payments, hosted payments, payment links and payment sessions.
+var paymentChallengeIndicatorWireValues = []string{
+	"no_preference",
+	"no_challenge_requested",
+	"challenge_requested",
+	"challenge_requested_mandate",
+}
+
+func TestSessionChallengeIndicator_MatchesSpecValueSet(t *testing.T) {
+	assert.Len(t, sessionChallengeIndicatorValues, 9)
+
+	for i, value := range sessionChallengeIndicatorValues {
+		assert.Equal(t, sessionChallengeIndicatorWireValues[i], string(value))
+	}
+}
+
+func TestSessionChallengeIndicator_SerializesOnSessionRequest(t *testing.T) {
+	for i, value := range sessionChallengeIndicatorValues {
+		request := SessionRequest{ChallengeIndicator: value}
+
+		data, err := json.Marshal(request)
+		assert.Nil(t, err)
+
+		var decoded map[string]interface{}
+		assert.Nil(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, sessionChallengeIndicatorWireValues[i], decoded["challenge_indicator"])
+	}
+}
+
+// The API Reference specifies only the four base values for the session response field, but the
+// request accepts nine. An exemption value echoed back must still deserialize.
+func TestSessionChallengeIndicator_DeserializesOnGetSessionResponse(t *testing.T) {
+	for i, wire := range sessionChallengeIndicatorWireValues {
+		payload := []byte(`{"challenge_indicator":"` + wire + `"}`)
+
+		var response GetSessionResponse
+		assert.Nil(t, json.Unmarshal(payload, &response))
+		assert.NotNil(t, response.ChallengeIndicator)
+		assert.Equal(t, sessionChallengeIndicatorValues[i], *response.ChallengeIndicator)
+	}
+}
+
+func TestNewSessionRequest_DefaultsToNoPreference(t *testing.T) {
+	request := NewSessionRequest()
+
+	assert.Equal(t, SessionChallengeNoPreference, request.ChallengeIndicator)
+
+	data, err := json.Marshal(request)
+	assert.Nil(t, err)
+	assert.Contains(t, string(data), `"challenge_indicator":"no_preference"`)
+}
+
+// The shared payments enum must stay narrow: the exemption values are rejected by the
+// 3ds.challenge_indicator fields that use common.ChallengeIndicator. This is the guard the split
+// exists to provide.
+func TestCommonChallengeIndicator_StaysNarrow(t *testing.T) {
+	shared := []common.ChallengeIndicator{
+		common.NoPreference,
+		common.NoChallengeRequested,
+		common.ChallengeRequested,
+		common.ChallengeRequestedMandate,
+	}
+
+	assert.Len(t, shared, len(paymentChallengeIndicatorWireValues))
+	for i, value := range shared {
+		assert.Equal(t, paymentChallengeIndicatorWireValues[i], string(value))
+	}
+
+	exemptions := []string{
+		"low_value",
+		"trusted_listing",
+		"trusted_listing_prompt",
+		"transaction_risk_assessment",
+		"data_share",
+	}
+	for _, exemption := range exemptions {
+		assert.NotContains(t, paymentChallengeIndicatorWireValues, exemption)
+		assert.Contains(t, sessionChallengeIndicatorWireValues, exemption)
+	}
+}

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -13,6 +13,38 @@ const (
 	IssuerFingerprintPath = "issuer-fingerprint"
 )
 
+// SessionChallengeIndicator indicates whether a challenge is requested for this session.
+//
+// Used by SessionRequest.ChallengeIndicator for POST /sessions. This is the only field in the API
+// that accepts the exemption values below; the 3ds.challenge_indicator field on payments, hosted
+// payments, payment links and payment sessions accepts only the first four values and is modelled by
+// common.ChallengeIndicator.
+//
+// The following are requests for exemption: SessionChallengeLowValue,
+// SessionChallengeTrustedListing, SessionChallengeTrustedListingPrompt and
+// SessionChallengeTransactionRiskAssessment. If an exemption cannot be applied, then the value
+// SessionChallengeNoChallengeRequested will be used instead.
+//
+// [Optional]
+// Default: SessionChallengeNoPreference
+// max 50 characters
+//
+// The constants are prefixed because package common already declares LowValue, TrustedListing,
+// TrustedListingPrompt and TransactionRiskAssessment as Exemption values.
+type SessionChallengeIndicator string
+
+const (
+	SessionChallengeNoPreference              SessionChallengeIndicator = "no_preference"
+	SessionChallengeNoChallengeRequested      SessionChallengeIndicator = "no_challenge_requested"
+	SessionChallengeRequested                 SessionChallengeIndicator = "challenge_requested"
+	SessionChallengeRequestedMandate          SessionChallengeIndicator = "challenge_requested_mandate"
+	SessionChallengeLowValue                  SessionChallengeIndicator = "low_value"
+	SessionChallengeTrustedListing            SessionChallengeIndicator = "trusted_listing"
+	SessionChallengeTrustedListingPrompt      SessionChallengeIndicator = "trusted_listing_prompt"
+	SessionChallengeTransactionRiskAssessment SessionChallengeIndicator = "transaction_risk_assessment"
+	SessionChallengeDataShare                 SessionChallengeIndicator = "data_share"
+)
+
 type AuthenticationType string
 
 const (
@@ -27,7 +59,7 @@ type Category string
 
 const (
 	Payment    Category = "payment"
-	NonPayment Category = "nonPayment"
+	NonPayment Category = "non_payment"
 )
 
 type TransactionType string
@@ -37,7 +69,7 @@ const (
 	CheckAcceptance          TransactionType = "check_acceptance"
 	GoodsService             TransactionType = "goods_service"
 	PrepaidActivationAndLoad TransactionType = "prepaid_activation_and_load"
-	QuashiCardTransaction    TransactionType = "quashi_card_transaction"
+	QuasiCardTransaction     TransactionType = "quasi_card_transaction"
 )
 
 type SessionStatus string

--- a/sessions/sessions_enums_test.go
+++ b/sessions/sessions_enums_test.go
@@ -1,0 +1,108 @@
+package sessions
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/common"
+	"github.com/checkout/checkout-sdk-go/v2/sessions/sources"
+)
+
+// Spec-conformance guards for the sessions enums. These types carry the raw wire values sent to and
+// returned by the API, so a typo is invisible at compile time and only fails against the live API.
+
+// validAPIValue matches snake_case, or a single uppercase letter for the Y/N/U style codes.
+var validAPIValue = regexp.MustCompile(`^([a-z0-9_]+|[A-Z])$`)
+
+func TestCategory_MatchesSpec(t *testing.T) {
+	// Spec: ["payment", "non_payment"]. Guards against the camelCase "nonPayment", which the API
+	// rejects.
+	assert.Equal(t, "payment", string(Payment))
+	assert.Equal(t, "non_payment", string(NonPayment))
+}
+
+func TestTransactionType_MatchesSpec(t *testing.T) {
+	// Spec: the five values below. The correct spelling is "quasi_card_transaction".
+	assert.Equal(t, "account_funding", string(AccountFunding))
+	assert.Equal(t, "check_acceptance", string(CheckAcceptance))
+	assert.Equal(t, "goods_service", string(GoodsService))
+	assert.Equal(t, "prepaid_activation_and_load", string(PrepaidActivationAndLoad))
+	assert.Equal(t, "quasi_card_transaction", string(QuasiCardTransaction))
+}
+
+func TestShippingIndicator_MatchesSpec(t *testing.T) {
+	// Spec: the seven values below. This type previously held a single wrong value, "visa", which
+	// left MerchantRiskInfo.ShippingIndicator unusable.
+	expected := []string{
+		"billing_address",
+		"another_address_on_file",
+		"not_on_file",
+		"store_pick_up",
+		"digital_goods",
+		"travel_and_event_no_shipping",
+		"other",
+	}
+	actual := []string{
+		string(ShippingBillingAddress),
+		string(ShippingAnotherAddressOnFile),
+		string(ShippingNotOnFile),
+		string(ShippingStorePickUp),
+		string(ShippingDigitalGoods),
+		string(ShippingTravelAndEventNoShipping),
+		string(ShippingOther),
+	}
+
+	assert.Equal(t, expected, actual)
+	assert.NotContains(t, actual, "visa")
+}
+
+func TestThreeDsMethodCompletion_IsUppercase(t *testing.T) {
+	// Spec enum is Y/N/U with minLength and maxLength 1. Lowercase values are rejected by the API.
+	assert.Equal(t, "Y", string(common.Y))
+	assert.Equal(t, "N", string(common.N))
+	assert.Equal(t, "U", string(common.U))
+}
+
+func TestSessionScheme_MatchesSpec(t *testing.T) {
+	// Spec: eight values. "discover" and "upi" were previously missing.
+	expected := []string{
+		"amex", "cartes_bancaires", "diners", "discover",
+		"jcb", "mastercard", "upi", "visa",
+	}
+	actual := []string{
+		string(sources.Amex), string(sources.CartesBancaires), string(sources.Diners),
+		string(sources.Discover), string(sources.Jcb), string(sources.Mastercard),
+		string(sources.Upi), string(sources.Visa),
+	}
+
+	assert.Equal(t, expected, actual)
+	assert.Len(t, actual, 8)
+}
+
+// Structural guard: every wire value used by the sessions surface must be snake_case or a single
+// uppercase code. This catches camelCase leaking into a value, which is how "nonPayment" survived.
+func TestEverySessionsWireValueIsWellFormed(t *testing.T) {
+	values := []string{
+		string(Payment), string(NonPayment),
+		string(AccountFunding), string(CheckAcceptance), string(GoodsService),
+		string(PrepaidActivationAndLoad), string(QuasiCardTransaction),
+		string(ShippingBillingAddress), string(ShippingAnotherAddressOnFile),
+		string(ShippingNotOnFile), string(ShippingStorePickUp), string(ShippingDigitalGoods),
+		string(ShippingTravelAndEventNoShipping), string(ShippingOther),
+		string(common.Y), string(common.N), string(common.U),
+		string(sources.Amex), string(sources.CartesBancaires), string(sources.Diners),
+		string(sources.Discover), string(sources.Jcb), string(sources.Mastercard),
+		string(sources.Upi), string(sources.Visa),
+		string(ThreeDsExperience), string(GoogleSpaExperience),
+	}
+	for _, value := range sessionChallengeIndicatorWireValues {
+		values = append(values, value)
+	}
+
+	assert.Greater(t, len(values), 30)
+	for _, value := range values {
+		assert.Regexp(t, validAPIValue, value, "%q is not a valid API value", value)
+	}
+}

--- a/sessions/sessions_enums_test.go
+++ b/sessions/sessions_enums_test.go
@@ -1,6 +1,7 @@
 package sessions
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 
@@ -81,6 +82,61 @@ func TestSessionScheme_MatchesSpec(t *testing.T) {
 	assert.Len(t, actual, 8)
 }
 
+func TestExperienceStatus_MatchesSpec(t *testing.T) {
+	// Spec: PreferredExperiences status enum is the four values below.
+	expected := []string{"available", "unprocessed", "processed", "unavailable"}
+	actual := []string{
+		string(ExperienceAvailable), string(ExperienceUnprocessed),
+		string(ExperienceProcessed), string(ExperienceUnavailable),
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+// The 3ds, preferred_experiences, experience and google_spa fields of GetSessionResponse were
+// previously unmodelled, so the Google SPA and preferred-experience data the API returns was dropped.
+func TestSessionDetails_DeserializesTheExperienceFields(t *testing.T) {
+	payload := []byte(`{
+		"3ds":{"challenge_request":"creq","interaction_counter":"03",
+			"error_details":{"error_code":"101","error_component":"D","error_detail":"acctNumber",
+			"error_description":"missing"}},
+		"preferred_experiences":{"google_spa":{"status":"available"},
+			"3ds":{"status":"processed","reason":["Invalid response"]}},
+		"experience":"3ds",
+		"google_spa":{"challenge_url":"https://google.example/challenge","initial_timeout":"5",
+			"max_timeout":"10","iframe":{"height":"400","width":"250"},
+			"token":{"number":"4242","expiry_month":12,"expiry_year":2030}}
+	}`)
+
+	var details SessionDetails
+	assert.Nil(t, json.Unmarshal(payload, &details))
+
+	assert.NotNil(t, details.ThreeDs)
+	assert.Equal(t, "creq", details.ThreeDs.ChallengeRequest)
+	assert.Equal(t, "03", details.ThreeDs.InteractionCounter)
+	assert.NotNil(t, details.ThreeDs.ErrorDetails)
+	assert.Equal(t, "101", details.ThreeDs.ErrorDetails.ErrorCode)
+	assert.Equal(t, "D", details.ThreeDs.ErrorDetails.ErrorComponent)
+
+	assert.NotNil(t, details.PreferredExperiences)
+	assert.NotNil(t, details.PreferredExperiences.GoogleSpa)
+	assert.Equal(t, ExperienceAvailable, details.PreferredExperiences.GoogleSpa.Status)
+	assert.NotNil(t, details.PreferredExperiences.ThreeDs)
+	assert.Equal(t, ExperienceProcessed, details.PreferredExperiences.ThreeDs.Status)
+	assert.Equal(t, []string{"Invalid response"}, details.PreferredExperiences.ThreeDs.Reason)
+
+	assert.Equal(t, ThreeDsExperience, details.Experience)
+
+	assert.NotNil(t, details.GoogleSpa)
+	assert.Equal(t, "https://google.example/challenge", details.GoogleSpa.ChallengeUrl)
+	assert.Equal(t, "5", details.GoogleSpa.InitialTimeout)
+	assert.NotNil(t, details.GoogleSpa.Iframe)
+	assert.Equal(t, "400", details.GoogleSpa.Iframe.Height)
+	assert.NotNil(t, details.GoogleSpa.Token)
+	assert.Equal(t, "4242", details.GoogleSpa.Token.Number)
+	assert.Equal(t, 12, details.GoogleSpa.Token.ExpiryMonth)
+}
+
 // Structural guard: every wire value used by the sessions surface must be snake_case or a single
 // uppercase code. This catches camelCase leaking into a value, which is how "nonPayment" survived.
 func TestEverySessionsWireValueIsWellFormed(t *testing.T) {
@@ -97,9 +153,7 @@ func TestEverySessionsWireValueIsWellFormed(t *testing.T) {
 		string(sources.Upi), string(sources.Visa),
 		string(ThreeDsExperience), string(GoogleSpaExperience),
 	}
-	for _, value := range sessionChallengeIndicatorWireValues {
-		values = append(values, value)
-	}
+	values = append(values, sessionChallengeIndicatorWireValues...)
 
 	assert.Greater(t, len(values), 30)
 	for _, value := range values {

--- a/sessions/sessions_requests.go
+++ b/sessions/sessions_requests.go
@@ -10,10 +10,25 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/sessions/sources"
 )
 
+// ShippingIndicator indicates the shipping method chosen for the transaction.
+//
+// Used by MerchantRiskInfo.ShippingIndicator. Choose the option that accurately describes the
+// cardholder's specific transaction.
+//
+// [Optional]
+//
+// The constants are prefixed to avoid clashing with the scheme and payment-method constants of the
+// same name elsewhere in the SDK.
 type ShippingIndicator string
 
 const (
-	Visa ShippingIndicator = "visa"
+	ShippingBillingAddress           ShippingIndicator = "billing_address"
+	ShippingAnotherAddressOnFile     ShippingIndicator = "another_address_on_file"
+	ShippingNotOnFile                ShippingIndicator = "not_on_file"
+	ShippingStorePickUp              ShippingIndicator = "store_pick_up"
+	ShippingDigitalGoods             ShippingIndicator = "digital_goods"
+	ShippingTravelAndEventNoShipping ShippingIndicator = "travel_and_event_no_shipping"
+	ShippingOther                    ShippingIndicator = "other"
 )
 
 type Experience string
@@ -58,7 +73,7 @@ type (
 		AuthenticationType            AuthenticationType         `json:"authentication_type,omitempty"`
 		AuthenticationCategory        Category                   `json:"authentication_category,omitempty"`
 		AccountInfo                   *CardholderAccountInfo     `json:"account_info,omitempty"`
-		ChallengeIndicator            common.ChallengeIndicator  `json:"challenge_indicator,omitempty"`
+		ChallengeIndicator            SessionChallengeIndicator  `json:"challenge_indicator,omitempty"`
 		BillingDescriptor             *SessionsBillingDescriptor `json:"billing_descriptor,omitempty"`
 		Reference                     string                     `json:"reference,omitempty"`
 		MerchantRiskInfo              *MerchantRiskInfo          `json:"merchant_risk_info,omitempty"`
@@ -87,7 +102,7 @@ func NewSessionRequest() *SessionRequest {
 		Source:                 sources.NewSessionCardSource(),
 		AuthenticationType:     RegularAuthType,
 		AuthenticationCategory: Payment,
-		ChallengeIndicator:     common.NoPreference,
+		ChallengeIndicator:     SessionChallengeNoPreference,
 		TransactionType:        GoodsService,
 	}
 }

--- a/sessions/sessions_requests.go
+++ b/sessions/sessions_requests.go
@@ -64,6 +64,11 @@ type (
 )
 
 type (
+	// SessionRequest is the request body for POST /sessions.
+	//
+	// It declares exactly the 24 properties of the SessionRequest schema. prior_transaction_reference
+	// was carried here from a June 2022 sessions update but is absent from the current API Reference,
+	// from the API schema search and from the developer documentation, so it is no longer declared.
 	SessionRequest struct {
 		Source                        sources.SessionSource      `json:"source,omitempty"`
 		Amount                        int64                      `json:"amount,omitempty"`
@@ -77,7 +82,6 @@ type (
 		BillingDescriptor             *SessionsBillingDescriptor `json:"billing_descriptor,omitempty"`
 		Reference                     string                     `json:"reference,omitempty"`
 		MerchantRiskInfo              *MerchantRiskInfo          `json:"merchant_risk_info,omitempty"`
-		PriorTransactionReference     string                     `json:"prior_transaction_reference,omitempty"`
 		TransactionType               TransactionType            `json:"transaction_type,omitempty"`
 		ShippingAddress               *sources.SessionAddress    `json:"shipping_address,omitempty"`
 		ShippingAddressMatchesBilling bool                       `json:"shipping_address_matches_billing,omitempty"`

--- a/sessions/sessions_responses.go
+++ b/sessions/sessions_responses.go
@@ -39,6 +39,17 @@ const (
 	Y ResponseCode = "Y"
 )
 
+// ExperienceStatus is the status of a preferred experience on the session response.
+// The constants are prefixed because Unavailable is already declared as a SessionStatus.
+type ExperienceStatus string
+
+const (
+	ExperienceAvailable   ExperienceStatus = "available"
+	ExperienceUnprocessed ExperienceStatus = "unprocessed"
+	ExperienceProcessed   ExperienceStatus = "processed"
+	ExperienceUnavailable ExperienceStatus = "unavailable"
+)
+
 type TrustedBeneficiaryStatusType string
 
 const (
@@ -118,7 +129,73 @@ type (
 		Exemption              *ThreeDsExemption          `json:"exemption,omitempty"`
 		FlowType               common.ThreeDsFlowType     `json:"flow_type,omitempty"`
 		SchemeInfo             *SchemeInfo                `json:"scheme_info,omitempty"`
+		ThreeDs                *ThreeDsInfo               `json:"3ds,omitempty"`
+		PreferredExperiences   *PreferredExperiences      `json:"preferred_experiences,omitempty"`
+		Experience             Experience                 `json:"experience,omitempty"`
+		GoogleSpa              *GoogleSpaInfo             `json:"google_spa,omitempty"`
 		Links                  map[string]common.Link     `json:"_links,omitempty"`
+	}
+
+	// ThreeDsInfo provides more information about the 3DS experience.
+	ThreeDsInfo struct {
+		// ChallengeRequest is the CReq message, encoded in Base 64.
+		ChallengeRequest string `json:"challenge_request,omitempty"`
+		// InteractionCounter is the number of authentication attempts performed by the cardholder.
+		// max 2 characters
+		InteractionCounter string `json:"interaction_counter,omitempty"`
+		// ErrorDetails provides additional information about the error returned.
+		ErrorDetails *ThreeDsErrorDetails `json:"error_details,omitempty"`
+	}
+
+	// ThreeDsErrorDetails provides additional information about the error returned.
+	ThreeDsErrorDetails struct {
+		// ErrorCode identifies the type of issue.
+		ErrorCode string `json:"error_code,omitempty"`
+		// ErrorComponent specifies which 3D Secure component identified the error.
+		ErrorComponent string `json:"error_component,omitempty"`
+		// ErrorDetail provides additional details about the issue.
+		// max 2048 characters
+		ErrorDetail string `json:"error_detail,omitempty"`
+		// ErrorDescription describes the issue identified.
+		// max 2048 characters
+		ErrorDescription string `json:"error_description,omitempty"`
+	}
+
+	// PreferredExperiences reports the outcome of each experience requested for the session.
+	PreferredExperiences struct {
+		GoogleSpa *ExperienceOutcome `json:"google_spa,omitempty"`
+		ThreeDs   *ExperienceOutcome `json:"3ds,omitempty"`
+	}
+
+	// ExperienceOutcome is the status of a single preferred experience.
+	ExperienceOutcome struct {
+		Status ExperienceStatus `json:"status,omitempty"`
+		// Reason lists the reason(s) why processing the experience was unsuccessful.
+		Reason []string `json:"reason,omitempty"`
+	}
+
+	// GoogleSpaInfo holds the details of Google SPA (Secure Payment Authentication). The hosted
+	// variant returns only Token; the non-hosted variant returns the challenge details as well.
+	GoogleSpaInfo struct {
+		ChallengeUrl   string           `json:"challenge_url,omitempty"`
+		InitialTimeout string           `json:"initial_timeout,omitempty"`
+		MaxTimeout     string           `json:"max_timeout,omitempty"`
+		Iframe         *GoogleSpaIframe `json:"iframe,omitempty"`
+		Token          *GoogleSpaToken  `json:"token,omitempty"`
+	}
+
+	// GoogleSpaIframe holds the details of the challenge iframe displayed in the cardholder browser
+	// window.
+	GoogleSpaIframe struct {
+		Height string `json:"height,omitempty"`
+		Width  string `json:"width,omitempty"`
+	}
+
+	// GoogleSpaToken is the token for the given PAN provisioned and authenticated.
+	GoogleSpaToken struct {
+		Number      string `json:"number,omitempty"`
+		ExpiryMonth int    `json:"expiry_month,omitempty"`
+		ExpiryYear  int    `json:"expiry_year,omitempty"`
 	}
 
 	GetSessionResponse struct {

--- a/sessions/sessions_responses.go
+++ b/sessions/sessions_responses.go
@@ -100,7 +100,7 @@ type (
 		Installment            *Installment               `json:"installment,omitempty"`
 		InitialTransaction     *InitialTransaction        `json:"initial_transaction,omitempty"`
 		AuthenticationDate     *time.Time                 `json:"authentication_date,omitempty"`
-		ChallengeIndicator     *common.ChallengeIndicator `json:"challenge_indicator,omitempty"`
+		ChallengeIndicator     *SessionChallengeIndicator `json:"challenge_indicator,omitempty"`
 		Optimization           *Optimization              `json:"optimization,omitempty"`
 		Certificates           *DsPublicKeys              `json:"certificates,omitempty"`
 		Approved               bool                       `json:"approved,omitempty"`

--- a/sessions/sources/session_sources.go
+++ b/sessions/sources/session_sources.go
@@ -19,8 +19,10 @@ const (
 	Amex            SessionScheme = "amex"
 	CartesBancaires SessionScheme = "cartes_bancaires"
 	Diners          SessionScheme = "diners"
+	Discover        SessionScheme = "discover"
 	Jcb             SessionScheme = "jcb"
 	Mastercard      SessionScheme = "mastercard"
+	Upi             SessionScheme = "upi"
 	Visa            SessionScheme = "visa"
 )
 

--- a/test/sessions_test.go
+++ b/test/sessions_test.go
@@ -26,7 +26,7 @@ func TestRequestSession(t *testing.T) {
 			request: getNonHostedSession(
 				getBrowserChannel(),
 				sessions.Payment,
-				common.NoPreference,
+				sessions.SessionChallengeNoPreference,
 				sessions.GoodsService,
 			),
 			checker: func(response *sessions.SessionResponse, err error) {
@@ -44,7 +44,7 @@ func TestRequestSession(t *testing.T) {
 			request: getNonHostedSession(
 				getAppChannel(),
 				sessions.Payment,
-				common.NoPreference,
+				sessions.SessionChallengeNoPreference,
 				sessions.GoodsService,
 			),
 			checker: func(response *sessions.SessionResponse, err error) {
@@ -71,7 +71,7 @@ func TestRequestSession(t *testing.T) {
 func TestGetSessionDetailsBrowser(t *testing.T) {
 	session := createSession(t, getNonHostedSession(getBrowserChannel(),
 		sessions.Payment,
-		common.NoPreference,
+		sessions.SessionChallengeNoPreference,
 		sessions.GoodsService))
 
 	cases := []struct {
@@ -127,7 +127,7 @@ func TestGetSessionDetailsMerchantInitiated(t *testing.T) {
 	t.Skip("unavailable")
 	session := createSession(t, getNonHostedSession(getMerchantInitiated(),
 		sessions.Payment,
-		common.NoPreference,
+		sessions.SessionChallengeNoPreference,
 		sessions.GoodsService))
 
 	cases := []struct {
@@ -386,7 +386,7 @@ func getAppChannel() channels.Channel {
 func getNonHostedSession(
 	channel channels.Channel,
 	category sessions.Category,
-	indicator common.ChallengeIndicator,
+	indicator sessions.SessionChallengeIndicator,
 	transaction sessions.TransactionType,
 ) sessions.SessionRequest {
 	sessionAddress := &sources.SessionAddress{
@@ -483,7 +483,7 @@ func getHostedSession() sessions.SessionRequest {
 	sessionRequest.ProcessingChannelId = "pc_5jp2az55l3cuths25t5p3xhwru"
 	sessionRequest.AuthenticationType = sessions.RegularAuthType
 	sessionRequest.AuthenticationCategory = sessions.Payment
-	sessionRequest.ChallengeIndicator = common.NoPreference
+	sessionRequest.ChallengeIndicator = sessions.SessionChallengeNoPreference
 	sessionRequest.Reference = "ORD-5023-4E89"
 	sessionRequest.TransactionType = sessions.GoodsService
 	sessionRequest.ShippingAddress = sessionAddress

--- a/test/workflows_test.go
+++ b/test/workflows_test.go
@@ -699,7 +699,7 @@ func TestTestWorkflow(t *testing.T) {
 	workflow := getWorkflow(t, createWorkflow(t).Id)
 
 	var request = events.EventTypesRequest{
-		[]string{"payment_approved",
+		EventTypes: []string{"payment_approved",
 			"payment_declined",
 			"card_verification_declined",
 			"card_verified",


### PR DESCRIPTION
This pull request makes several improvements and corrections to the session-related enums, types, and tests to ensure strict conformance with the API specification. The changes include fixing enum values to match the spec, introducing new enums for session challenge indicators and shipping indicators, and adding comprehensive tests to prevent future regressions or typos. The updates also clarify the separation between session-specific and payment-specific challenge indicators, and expand support for additional card schemes.

**Key changes include:**

### API enum and value corrections

* Changed several enum values to match the API spec, including updating `ThreeDsMethodCompletion` values to uppercase (`"Y"`, `"N"`, `"U"`), correcting `Category` from `"nonPayment"` to `"non_payment"`, and fixing `TransactionType` from `"quashi_card_transaction"` to `"quasi_card_transaction"`. [[1]](diffhunk://#diff-a70f47b70b2d542f3eaa01a097d0f6d97e1f49cee567e258d4afc2a79f07af92L148-R150) [[2]](diffhunk://#diff-494b6a11ab20c4fc611813c79fc9b3acd9f043577c3def41558e1e84ed1889e9L30-R62) [[3]](diffhunk://#diff-494b6a11ab20c4fc611813c79fc9b3acd9f043577c3def41558e1e84ed1889e9L40-R72)

* Added missing values to `SessionScheme` to support `"discover"` and `"upi"`, ensuring all supported schemes are included.

### New and updated enums

* Introduced `SessionChallengeIndicator` to distinguish session-specific challenge indicator values (including exemption values) from the more limited `common.ChallengeIndicator` used elsewhere. Updated all session request/response types and related test helpers to use this new enum. [[1]](diffhunk://#diff-494b6a11ab20c4fc611813c79fc9b3acd9f043577c3def41558e1e84ed1889e9R16-R47) [[2]](diffhunk://#diff-480be572221c83a7a9bb079799b099443d5e091bb2e639af05722799b6616e49L61-R76) [[3]](diffhunk://#diff-480be572221c83a7a9bb079799b099443d5e091bb2e639af05722799b6616e49L90-R105) [[4]](diffhunk://#diff-c501a0169f32eb772403270ceb38b682774f83dfab1a4a4e2f8f79958bf90e8cL103-R103) [[5]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L29-R29) [[6]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L47-R47) [[7]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L74-R74) [[8]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L130-R130) [[9]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L389-R389) [[10]](diffhunk://#diff-146c64ad405056b7a7efab5a2f86c2e364d87bd5c5ec11cb1cd472cb684fe644L486-R486)

* Added a new `ShippingIndicator` enum with all valid values per the spec, replacing the previous incorrect `"visa"` value.

### Test coverage and spec guards

* Added comprehensive tests (`sessions_enums_test.go` and `challenge_indicator_test.go`) to verify that all enum values match the API spec, check for valid wire values, and prevent incorrect or unsupported values from being used. These tests serve as a guard against typos and future regressions. [[1]](diffhunk://#diff-62156f26977d5617dec82848ea5edd1737f06d0306356f5b47f95bdaa4d3de93R1-R108) [[2]](diffhunk://#diff-ccfc14fe90fb77b1c50fdf66e6a8405fb7b1514058c30c3963219d53d72ca8f1R1-R118)

### Miscellaneous

* Fixed a bug in the workflow tests by correcting the initialization of `EventTypesRequest` to use the proper field name.