### PR TITLE
feat!: require WithEnvironmentSubdomain or an explicit WithLegacyDomain opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ import (
 
 api, err := checkout.Builder().
                      OAuth().
-                     WithAuthorizationUri("https://access.sandbox.checkout.com/connect/token"). // optional, custom authorization URI
                      WithClientCredentials("client_id", "client_secret").
                      WithEnvironment(configuration.Sandbox()).
                      WithEnvironmentSubdomain("subdomain"). // required, the first 8 characters of your client ID

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Make sure your project is using Go Modules:
 ```sh
 # For v2.x (current)
-go get github.com/checkout/checkout-sdk-go/v2@v2.0.0
+go get github.com/checkout/checkout-sdk-go/v2
 
 # For v1.x (legacy)
 go get github.com/checkout/checkout-sdk-go@v1.9.0
@@ -65,6 +65,10 @@ account [here](https://www.checkout.com/get-test-account).
 
 **PLEASE NEVER SHARE OR PUBLISH YOUR CHECKOUT CREDENTIALS.**
 
+### Subdomain value
+
+Requests must be made through your merchant-specific subdomain (MSSD): the first 8 characters of your client ID (excluding `cli_`). For example, if your client ID is `cli_vkuhvk4vjn2edkps7dfsq6emqm`, your subdomain is `vkuhvk4v`. When `WithEnvironmentSubdomain` is set the SDK sends requests to `https://vkuhvk4v.api.checkout.com`. See [Base URLs](https://api-reference.checkout.com/#section/Base-URLs) and [API endpoints](https://www.checkout.com/docs/developer-resources/api/api-endpoints) for further details, and for where to find your unique client ID.
+
 ### Default
 
 Default keys client instantiation can be done as follows:
@@ -78,6 +82,7 @@ import (
 api, err := checkout.Builder().
                      StaticKeys().
                      WithEnvironment(configuration.Sandbox()).
+                     WithEnvironmentSubdomain("subdomain"). // required, the first 8 characters of your client ID
                      WithSecretKey("secret_key").
                      WithPublicKey("public_key"). // optional, only required for operations related with tokens
                      Build()
@@ -98,6 +103,7 @@ api, err := checkout.Builder().
                      WithAuthorizationUri("https://access.sandbox.checkout.com/connect/token"). // optional, custom authorization URI
                      WithClientCredentials("client_id", "client_secret").
                      WithEnvironment(configuration.Sandbox()).
+                     WithEnvironmentSubdomain("subdomain"). // required, the first 8 characters of your client ID
                      WithScopes(getOAuthScopes()).
                      Build()
 ```
@@ -115,6 +121,7 @@ import (
 api, err := checkout.Builder().
                      Previous().
                      WithEnvironment(configuration.Sandbox()).
+                     WithEnvironmentSubdomain("subdomain"). // optional for the Previous platform
                      WithSecretKey("secret_key").
                      WithPublicKey("public_key"). // optional, only required for operations related with tokens
                      Build()
@@ -241,6 +248,23 @@ api := checkout.Builder().
     WithEnableTelemetry(false).
     Build()
 ```
+
+## Legacy domain (emergency use only)
+
+> :warning: **Only use if merchant specific sub domains are causing issues.** Connecting through your merchant-specific subdomain (see [Subdomain value](#subdomain-value)) is the supported way of using the Checkout.com API, and non-subdomain usage will be deprecated.
+
+If, in exceptional circumstances, you cannot use your merchant-specific subdomain, you can explicitly opt out by calling `WithLegacyDomain()` instead of `WithEnvironmentSubdomain(...)`:
+
+```go
+api, err := checkout.Builder().
+                     StaticKeys().
+                     WithEnvironment(configuration.Sandbox()).
+                     WithSecretKey("secret_key").
+                     WithLegacyDomain(). // deprecated, emergency fallback only
+                     Build()
+```
+
+This routes requests to `api.checkout.com` (or `api.sandbox.checkout.com`) and `access.checkout.com` (or `access.sandbox.checkout.com`). The method carries a `Deprecated:` doc comment, so `staticcheck` (SA1019) and editors will flag it. Exactly one of `WithEnvironmentSubdomain(...)` or `WithLegacyDomain()` must be set: `Build()` returns a `CheckoutArgumentError` if both, or neither, are. The Previous (ABC) platform predates merchant-specific subdomains and is exempt from this requirement.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ account [here](https://www.checkout.com/get-test-account).
 
 ### Subdomain value
 
-Requests must be made through your merchant-specific subdomain (MSSD): the first 8 characters of your client ID (excluding `cli_`). For example, if your client ID is `cli_vkuhvk4vjn2edkps7dfsq6emqm`, your subdomain is `vkuhvk4v`. When `WithEnvironmentSubdomain` is set the SDK sends requests to `https://vkuhvk4v.api.checkout.com`. See [Base URLs](https://api-reference.checkout.com/#section/Base-URLs) and [API endpoints](https://www.checkout.com/docs/developer-resources/api/api-endpoints) for further details, and for where to find your unique client ID.
+Requests must be made through your merchant-specific subdomain (MSSD): the first 8 characters of your client ID (excluding `cli_`). For example, if your client ID is `cli_vkuhvk4vjn2edkps7dfsq6emqm`, your subdomain is `vkuhvk4v`. When `WithEnvironmentSubdomain` is set the SDK sends requests to `https://vkuhvk4v.api.checkout.com`. See [Base URLs](https://api-reference.checkout.com/#section/Base-URLs) and [API endpoints](https://www.checkout.com/docs/developer-resources/api/api-endpoints) for further details, and for where to find your unique client ID. Private Link merchants use their pl- prefixed subdomain (for example pl-vkuhvk4v), which the SDK also accepts.
 
 ### Default
 

--- a/abc/checkout_previous_sdk_builder.go
+++ b/abc/checkout_previous_sdk_builder.go
@@ -84,7 +84,7 @@ func (b *CheckoutPreviousSdkBuilder) Build() (*Api, error) {
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
 	if environmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.EnableTelemetry, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/abc/checkout_previous_sdk_builder.go
+++ b/abc/checkout_previous_sdk_builder.go
@@ -21,7 +21,19 @@ func (b *CheckoutPreviousSdkBuilder) WithEnvironment(environment configuration.E
 }
 
 func (b *CheckoutPreviousSdkBuilder) WithEnvironmentSubdomain(subdomain string) *CheckoutPreviousSdkBuilder {
-	b.EnvironmentSubdomain = configuration.NewEnvironmentSubdomain(b.Environment, subdomain)
+	b.Subdomain = subdomain
+	return b
+}
+
+// WithLegacyDomain opts out of the merchant-specific subdomain, sending every request to the
+// shared hosts instead (api.checkout.com and access.checkout.com, or their sandbox equivalents).
+//
+// Deprecated: this is an emergency fallback for the rare case where the merchant-specific
+// subdomain cannot be used, and will be removed in a future release. Call
+// WithEnvironmentSubdomain instead.
+// See https://api-reference.checkout.com/#section/Base-URLs
+func (b *CheckoutPreviousSdkBuilder) WithLegacyDomain() *CheckoutPreviousSdkBuilder {
+	b.UseLegacyDomain = true
 	return b
 }
 
@@ -46,7 +58,18 @@ func (b *CheckoutPreviousSdkBuilder) WithSecretKey(secretKey string) *CheckoutPr
 }
 
 func (b *CheckoutPreviousSdkBuilder) Build() (*Api, error) {
-	err := b.ValidateSecretKey(configuration.PreviousSecretKeyPattern)
+	// The Previous (ABC) platform predates merchant-specific subdomains, so it is exempt from
+	// the mandatory WithEnvironmentSubdomain/WithLegacyDomain configuration.
+	if err := b.ValidateEnvironmentSettings(false); err != nil {
+		return nil, err
+	}
+
+	environmentSubdomain, err := b.GetEnvironmentSubdomain()
+	if err != nil {
+		return nil, err
+	}
+
+	err = b.ValidateSecretKey(configuration.PreviousSecretKeyPattern)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +83,8 @@ func (b *CheckoutPreviousSdkBuilder) Build() (*Api, error) {
 
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
-	if b.EnvironmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, b.EnvironmentSubdomain, b.HttpClient, b.Logger)
+	if environmentSubdomain != nil {
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -50,28 +50,13 @@ func NewConfiguration(
 
 func NewConfigurationWithSubdomain(
 	credentials SdkCredentials,
+	enableTelemetry *bool,
 	environment Environment,
 	environmentSubdomain *EnvironmentSubdomain,
 	client *http.Client,
 	logger StdLogger,
 ) *Configuration {
-	if environment == nil {
-		environment = Sandbox()
-	}
-
-	if client == nil {
-		client = common.BuildDefaultClient()
-	}
-
-	if logger == nil {
-		logger = DefaultLogger()
-	}
-
-	return &Configuration{
-		Credentials:          credentials,
-		Environment:          environment,
-		EnvironmentSubdomain: environmentSubdomain,
-		HttpClient:           *client,
-		Logger:               logger,
-	}
+	config := NewConfiguration(credentials, enableTelemetry, environment, client, logger)
+	config.EnvironmentSubdomain = environmentSubdomain
+	return config
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,37 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func buildSubdomain(t *testing.T) *EnvironmentSubdomain {
+	subdomain, err := NewEnvironmentSubdomain(Sandbox(), "vkuhvk4v")
+	assert.NoError(t, err)
+	assert.NotNil(t, subdomain)
+	return subdomain
+}
+
+func TestNewConfigurationWithSubdomainKeepsTelemetryEnabled(t *testing.T) {
+	config := NewConfigurationWithSubdomain(nil, boolPtr(true), Sandbox(), buildSubdomain(t), nil, nil)
+
+	assert.True(t, config.EnableTelemetry)
+	assert.NotNil(t, config.EnvironmentSubdomain)
+}
+
+func TestNewConfigurationWithSubdomainDefaultsTelemetryOn(t *testing.T) {
+	config := NewConfigurationWithSubdomain(nil, nil, Sandbox(), buildSubdomain(t), nil, nil)
+
+	assert.True(t, config.EnableTelemetry)
+	assert.NotNil(t, config.EnvironmentSubdomain)
+}
+
+func TestNewConfigurationWithSubdomainRespectsTelemetryOptOut(t *testing.T) {
+	config := NewConfigurationWithSubdomain(nil, boolPtr(false), Sandbox(), buildSubdomain(t), nil, nil)
+
+	assert.False(t, config.EnableTelemetry)
+	assert.NotNil(t, config.EnvironmentSubdomain)
+}

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -3,6 +3,8 @@ package configuration
 import (
 	"net/url"
 	"regexp"
+
+	"github.com/checkout/checkout-sdk-go/v2/errors"
 )
 
 type Environment interface {
@@ -21,33 +23,40 @@ type EnvironmentSubdomain struct {
 	AuthorizationUrl string
 }
 
-func NewEnvironmentSubdomain(environment Environment, subdomain string) *EnvironmentSubdomain {
-	apiUrl := createUrlWithSubdomain(environment.BaseUri(), subdomain)
-	authorizationUrl := createUrlWithSubdomain(environment.AuthorizationUri(), subdomain)
+func NewEnvironmentSubdomain(environment Environment, subdomain string) (*EnvironmentSubdomain, error) {
+	apiUrl, err := createUrlWithSubdomain(environment.BaseUri(), subdomain)
+	if err != nil {
+		return nil, err
+	}
+	authorizationUrl, err := createUrlWithSubdomain(environment.AuthorizationUri(), subdomain)
+	if err != nil {
+		return nil, err
+	}
 	return &EnvironmentSubdomain{
 		ApiUrl:           apiUrl,
 		AuthorizationUrl: authorizationUrl,
-	}
+	}, nil
 }
 
-// createUrlWithSubdomain applies subdomain transformation to any given URI.
-// If the subdomain is valid (alphanumeric pattern), prepends it to the host.
-// Otherwise, returns the original URI unchanged.
-func createUrlWithSubdomain(originalUrl string, subdomain string) string {
-	newEnvironment := originalUrl
-
+// createUrlWithSubdomain applies subdomain transformation to any given URI, prepending the
+// subdomain to the host. It returns an error when the subdomain is not a valid merchant-specific
+// subdomain, rather than quietly falling back to the shared host.
+func createUrlWithSubdomain(originalUrl, subdomain string) (string, error) {
 	regex := regexp.MustCompile("^(?:pl-)?[a-z0-9]+$")
 
-	if regex.MatchString(subdomain) {
-		merchantUrl, err := url.Parse(originalUrl)
-		if err != nil {
-			return newEnvironment
-		}
-		merchantUrl.Host = subdomain + "." + merchantUrl.Host
-		newEnvironment = merchantUrl.String()
+	if !regex.MatchString(subdomain) {
+		return "", errors.CheckoutArgumentError(
+			"invalid environment subdomain - provide your merchant-specific subdomain, the first " +
+				"8 characters of your client ID (see " +
+				"https://api-reference.checkout.com/#section/Base-URLs)")
 	}
 
-	return newEnvironment
+	merchantUrl, err := url.Parse(originalUrl)
+	if err != nil {
+		return "", err
+	}
+	merchantUrl.Host = subdomain + "." + merchantUrl.Host
+	return merchantUrl.String(), nil
 }
 
 type CheckoutEnv struct {

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -18,6 +18,10 @@ type Environment interface {
 	IsSandbox() bool
 }
 
+// subdomainRegex matches a merchant-specific subdomain, optionally carrying the pl- prefix used
+// by Private Link merchants.
+var subdomainRegex = regexp.MustCompile("^(?:pl-)?[a-z0-9]+$")
+
 type EnvironmentSubdomain struct {
 	ApiUrl           string
 	AuthorizationUrl string
@@ -42,12 +46,10 @@ func NewEnvironmentSubdomain(environment Environment, subdomain string) (*Enviro
 // subdomain to the host. It returns an error when the subdomain is not a valid merchant-specific
 // subdomain, rather than quietly falling back to the shared host.
 func createUrlWithSubdomain(originalUrl, subdomain string) (string, error) {
-	regex := regexp.MustCompile("^(?:pl-)?[a-z0-9]+$")
-
-	if !regex.MatchString(subdomain) {
+	if !subdomainRegex.MatchString(subdomain) {
 		return "", errors.CheckoutArgumentError(
-			"invalid environment subdomain - provide your merchant-specific subdomain, the first " +
-				"8 characters of your client ID (see " +
+			"invalid environment subdomain - provide your merchant-specific subdomain, typically " +
+				"your client ID excluding the cli_ prefix (see " +
 				"https://api-reference.checkout.com/#section/Base-URLs)")
 	}
 

--- a/configuration/sdk_builder.go
+++ b/configuration/sdk_builder.go
@@ -1,15 +1,52 @@
 package configuration
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/checkout/checkout-sdk-go/v2/errors"
+)
 
 type SdkBuilder struct {
-	EnableTelemetry      *bool
-	Environment          Environment
-	EnvironmentSubdomain *EnvironmentSubdomain
-	HttpClient           *http.Client
-	Logger               StdLogger
+	EnableTelemetry *bool
+	Environment     Environment
+	Subdomain       string
+	UseLegacyDomain bool
+	HttpClient      *http.Client
+	Logger          StdLogger
 }
 
 func (s *SdkBuilder) GetConfiguration(string, string) *Configuration {
 	return new(Configuration)
+}
+
+// GetEnvironmentSubdomain builds the merchant-specific subdomain URLs, or returns nil when the
+// caller opted out with the legacy domain. It is resolved at build time rather than when the
+// subdomain is set, so the order of the With... calls does not matter.
+func (s *SdkBuilder) GetEnvironmentSubdomain() (*EnvironmentSubdomain, error) {
+	if s.Subdomain == "" {
+		return nil, nil
+	}
+	return NewEnvironmentSubdomain(s.Environment, s.Subdomain)
+}
+
+// ValidateEnvironmentSettings enforces an explicit choice of domain. The merchant-specific
+// subdomain is how merchants should reach the API, so it is required unless the caller opts out
+// with UseLegacyDomain. Setting both, or neither, is a configuration error.
+//
+// requiresSubdomain is false for the Previous (ABC) platform, which predates merchant-specific
+// subdomains.
+func (s *SdkBuilder) ValidateEnvironmentSettings(requiresSubdomain bool) error {
+	if s.Subdomain != "" && s.UseLegacyDomain {
+		return errors.CheckoutArgumentError(
+			"WithEnvironmentSubdomain and WithLegacyDomain cannot both be set - provide only your " +
+				"merchant-specific subdomain")
+	}
+	if s.Subdomain == "" && !s.UseLegacyDomain && requiresSubdomain {
+		return errors.CheckoutArgumentError(
+			"environment subdomain is required - provide your merchant-specific subdomain (the " +
+				"first 8 characters of your client ID, see " +
+				"https://api-reference.checkout.com/#section/Base-URLs), or call WithLegacyDomain " +
+				"to opt out only if merchant specific sub domains are causing issues")
+	}
+	return nil
 }

--- a/configuration/sdk_builder.go
+++ b/configuration/sdk_builder.go
@@ -43,8 +43,8 @@ func (s *SdkBuilder) ValidateEnvironmentSettings(requiresSubdomain bool) error {
 	}
 	if s.Subdomain == "" && !s.UseLegacyDomain && requiresSubdomain {
 		return errors.CheckoutArgumentError(
-			"environment subdomain is required - provide your merchant-specific subdomain (the " +
-				"first 8 characters of your client ID, see " +
+			"environment subdomain is required - provide your merchant-specific subdomain (typically " +
+				"your client ID excluding the cli_ prefix, see " +
 				"https://api-reference.checkout.com/#section/Base-URLs), or call WithLegacyDomain " +
 				"to opt out only if merchant specific sub domains are causing issues")
 	}

--- a/nas/checkout_default_sdk_builder.go
+++ b/nas/checkout_default_sdk_builder.go
@@ -21,7 +21,19 @@ func (b *CheckoutDefaultSdkBuilder) WithEnvironment(environment configuration.En
 }
 
 func (b *CheckoutDefaultSdkBuilder) WithEnvironmentSubdomain(subdomain string) *CheckoutDefaultSdkBuilder {
-	b.EnvironmentSubdomain = configuration.NewEnvironmentSubdomain(b.Environment, subdomain)
+	b.Subdomain = subdomain
+	return b
+}
+
+// WithLegacyDomain opts out of the merchant-specific subdomain, sending every request to the
+// shared hosts instead (api.checkout.com and access.checkout.com, or their sandbox equivalents).
+//
+// Deprecated: this is an emergency fallback for the rare case where the merchant-specific
+// subdomain cannot be used, and will be removed in a future release. Call
+// WithEnvironmentSubdomain instead.
+// See https://api-reference.checkout.com/#section/Base-URLs
+func (b *CheckoutDefaultSdkBuilder) WithLegacyDomain() *CheckoutDefaultSdkBuilder {
+	b.UseLegacyDomain = true
 	return b
 }
 
@@ -46,7 +58,16 @@ func (b *CheckoutDefaultSdkBuilder) WithSecretKey(secretKey string) *CheckoutDef
 }
 
 func (b *CheckoutDefaultSdkBuilder) Build() (*Api, error) {
-	err := b.ValidateSecretKey(configuration.DefaultSecretKeyPattern)
+	if err := b.ValidateEnvironmentSettings(true); err != nil {
+		return nil, err
+	}
+
+	environmentSubdomain, err := b.GetEnvironmentSubdomain()
+	if err != nil {
+		return nil, err
+	}
+
+	err = b.ValidateSecretKey(configuration.DefaultSecretKeyPattern)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +81,8 @@ func (b *CheckoutDefaultSdkBuilder) Build() (*Api, error) {
 
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
-	if b.EnvironmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, b.EnvironmentSubdomain, b.HttpClient, b.Logger)
+	if environmentSubdomain != nil {
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/nas/checkout_default_sdk_builder.go
+++ b/nas/checkout_default_sdk_builder.go
@@ -82,7 +82,7 @@ func (b *CheckoutDefaultSdkBuilder) Build() (*Api, error) {
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
 	if environmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.EnableTelemetry, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/nas/checkout_oauth_sdk_builder.go
+++ b/nas/checkout_oauth_sdk_builder.go
@@ -103,7 +103,7 @@ func (b *CheckoutOAuthSdkBuilder) Build() (*Api, error) {
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
 	if environmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.EnableTelemetry, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/nas/checkout_oauth_sdk_builder.go
+++ b/nas/checkout_oauth_sdk_builder.go
@@ -42,7 +42,19 @@ func (b *CheckoutOAuthSdkBuilder) WithEnvironment(environment configuration.Envi
 }
 
 func (b *CheckoutOAuthSdkBuilder) WithEnvironmentSubdomain(subdomain string) *CheckoutOAuthSdkBuilder {
-	b.EnvironmentSubdomain = configuration.NewEnvironmentSubdomain(b.Environment, subdomain)
+	b.Subdomain = subdomain
+	return b
+}
+
+// WithLegacyDomain opts out of the merchant-specific subdomain, sending every request to the
+// shared hosts instead (api.checkout.com and access.checkout.com, or their sandbox equivalents).
+//
+// Deprecated: this is an emergency fallback for the rare case where the merchant-specific
+// subdomain cannot be used, and will be removed in a future release. Call
+// WithEnvironmentSubdomain instead.
+// See https://api-reference.checkout.com/#section/Base-URLs
+func (b *CheckoutOAuthSdkBuilder) WithLegacyDomain() *CheckoutOAuthSdkBuilder {
+	b.UseLegacyDomain = true
 	return b
 }
 
@@ -61,9 +73,18 @@ func (b *CheckoutOAuthSdkBuilder) Build() (*Api, error) {
 		return nil, errors.CheckoutArgumentError("Invalid OAuth 'client_id' or 'client_secret'")
 	}
 
+	if err := b.ValidateEnvironmentSettings(true); err != nil {
+		return nil, err
+	}
+
+	environmentSubdomain, subdomainErr := b.GetEnvironmentSubdomain()
+	if subdomainErr != nil {
+		return nil, subdomainErr
+	}
+
 	if b.AuthorizationUri == "" {
-		if b.EnvironmentSubdomain != nil {
-			b.AuthorizationUri = b.EnvironmentSubdomain.AuthorizationUrl
+		if environmentSubdomain != nil {
+			b.AuthorizationUri = environmentSubdomain.AuthorizationUrl
 		} else {
 			b.AuthorizationUri = b.SdkBuilder.Environment.AuthorizationUri()
 		}
@@ -81,8 +102,8 @@ func (b *CheckoutOAuthSdkBuilder) Build() (*Api, error) {
 
 	newConfiguration := configuration.NewConfiguration(sdkCredentials, b.EnableTelemetry, b.Environment, b.HttpClient, b.Logger)
 
-	if b.EnvironmentSubdomain != nil {
-		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, b.EnvironmentSubdomain, b.HttpClient, b.Logger)
+	if environmentSubdomain != nil {
+		newConfiguration = configuration.NewConfigurationWithSubdomain(sdkCredentials, b.Environment, environmentSubdomain, b.HttpClient, b.Logger)
 	}
 
 	return CheckoutApi(newConfiguration), nil

--- a/nas/checkout_oauth_sdk_builder.go
+++ b/nas/checkout_oauth_sdk_builder.go
@@ -77,6 +77,13 @@ func (b *CheckoutOAuthSdkBuilder) Build() (*Api, error) {
 		return nil, err
 	}
 
+	if b.AuthorizationUri != "" && b.Subdomain != "" {
+		return nil, errors.CheckoutArgumentError(
+			"authorization URI and environment subdomain cannot both be set - the token endpoint " +
+				"is derived from your subdomain; combine the authorization URI with " +
+				"WithLegacyDomain() if you need a custom token host")
+	}
+
 	environmentSubdomain, subdomainErr := b.GetEnvironmentSubdomain()
 	if subdomainErr != nil {
 		return nil, subdomainErr

--- a/test/accounts_test.go
+++ b/test/accounts_test.go
@@ -1069,6 +1069,10 @@ func buildFilesClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Marketplace, configuration.Files}).
+			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+			// so the token request would come back invalid_client. Opting out explicitly until
+			// they are.
+			WithLegacyDomain().
 			Build()
 	}
 
@@ -1083,6 +1087,10 @@ func buildPayoutsScheduleClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
+			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+			// so the token request would come back invalid_client. Opting out explicitly until
+			// they are.
+			WithLegacyDomain().
 			Build()
 	}
 
@@ -1097,6 +1105,10 @@ func buildAccountsClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
+			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+			// so the token request would come back invalid_client. Opting out explicitly until
+			// they are.
+			WithLegacyDomain().
 			Build()
 	}
 
@@ -1114,6 +1126,10 @@ func buildAccountsClientVersion(schemaVersion string) *nas.Api {
 		WithScopes([]string{configuration.Accounts}).
 		WithEnvironment(configuration.Sandbox()).
 		WithHttpClient(httpClient).
+		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+		// so the token request would come back invalid_client. Opting out explicitly until
+		// they are.
+		WithLegacyDomain().
 		Build()
 
 	return oauthAccountsClientVersion

--- a/test/accounts_test.go
+++ b/test/accounts_test.go
@@ -1069,9 +1069,8 @@ func buildFilesClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Marketplace, configuration.Files}).
-			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-			// so the token request would come back invalid_client. Opting out explicitly until
-			// they are.
+			// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+			// come back invalid_client. Opting out explicitly until they are provisioned.
 			WithLegacyDomain().
 			Build()
 	}
@@ -1087,9 +1086,8 @@ func buildPayoutsScheduleClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
-			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-			// so the token request would come back invalid_client. Opting out explicitly until
-			// they are.
+			// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+			// come back invalid_client. Opting out explicitly until they are provisioned.
 			WithLegacyDomain().
 			Build()
 	}
@@ -1105,9 +1103,8 @@ func buildAccountsClient() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
-			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-			// so the token request would come back invalid_client. Opting out explicitly until
-			// they are.
+			// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+			// come back invalid_client. Opting out explicitly until they are provisioned.
 			WithLegacyDomain().
 			Build()
 	}
@@ -1126,9 +1123,8 @@ func buildAccountsClientVersion(schemaVersion string) *nas.Api {
 		WithScopes([]string{configuration.Accounts}).
 		WithEnvironment(configuration.Sandbox()).
 		WithHttpClient(httpClient).
-		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-		// so the token request would come back invalid_client. Opting out explicitly until
-		// they are.
+		// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+		// come back invalid_client. Opting out explicitly until they are provisioned.
 		WithLegacyDomain().
 		Build()
 

--- a/test/accounts_test.go
+++ b/test/accounts_test.go
@@ -1065,8 +1065,8 @@ func buildFilesClient() *nas.Api {
 	if oauthFilesApi == nil {
 		oauthFilesApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Marketplace, configuration.Files}).
 			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
@@ -1083,8 +1083,8 @@ func buildPayoutsScheduleClient() *nas.Api {
 	if oauthPayoutsScheduleApi == nil {
 		oauthPayoutsScheduleApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
 			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,

--- a/test/accounts_test.go
+++ b/test/accounts_test.go
@@ -1065,8 +1065,8 @@ func buildFilesClient() *nas.Api {
 	if oauthFilesApi == nil {
 		oauthFilesApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Marketplace, configuration.Files}).
 			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
@@ -1083,8 +1083,8 @@ func buildPayoutsScheduleClient() *nas.Api {
 	if oauthPayoutsScheduleApi == nil {
 		oauthPayoutsScheduleApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{configuration.Accounts}).
 			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -34,7 +34,8 @@ func TestShouldCreateConfigurationWithSubdomain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Should create configuration with subdomain "+tc.subdomain, func(t *testing.T) {
-			subdomain := configuration.NewEnvironmentSubdomain(environment, tc.subdomain)
+			subdomain, err := configuration.NewEnvironmentSubdomain(environment, tc.subdomain)
+			assert.Nil(t, err)
 			config := configuration.NewConfigurationWithSubdomain(credentials, environment, subdomain, &http.Client{}, nil)
 
 			assert.NotNil(t, config)
@@ -44,36 +45,18 @@ func TestShouldCreateConfigurationWithSubdomain(t *testing.T) {
 	}
 }
 
-func TestShouldCreateConfigurationWithBadSubdomain(t *testing.T) {
-	credentials := new(mocks.CredentialsMock)
+func TestShouldFailWithBadSubdomain(t *testing.T) {
 	environment := configuration.Sandbox()
 
-	testCases := []struct {
-		subdomain       string
-		expectedApiUrl  string
-		expectedAuthUrl string
-	}{
-		{"", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"  ", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{" - ", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"a b", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"ab c1", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"foo-", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"-foo", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"ABC", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"test-123", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"foo-bar", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-		{"pl-", "https://api.sandbox.checkout.com", "https://access.sandbox.checkout.com/connect/token"},
-	}
+	badSubdomains := []string{"", "  ", " - ", "a b", "ab c1", "foo-", "-foo", "ABC", "test-123", "foo-bar", "pl-"}
 
-	for _, tc := range testCases {
-		t.Run("Should create configuration with bad subdomain "+tc.subdomain, func(t *testing.T) {
-			subdomain := configuration.NewEnvironmentSubdomain(environment, tc.subdomain)
-			config := configuration.NewConfigurationWithSubdomain(credentials, environment, subdomain, &http.Client{}, nil)
+	for _, badSubdomain := range badSubdomains {
+		t.Run("Should fail with bad subdomain "+badSubdomain, func(t *testing.T) {
+			subdomain, err := configuration.NewEnvironmentSubdomain(environment, badSubdomain)
 
-			assert.NotNil(t, config)
-			assert.Equal(t, tc.expectedApiUrl, config.EnvironmentSubdomain.ApiUrl)
-			assert.Equal(t, tc.expectedAuthUrl, config.EnvironmentSubdomain.AuthorizationUrl)
+			assert.Nil(t, subdomain)
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), "invalid environment subdomain")
 		})
 	}
 }
@@ -83,7 +66,8 @@ func TestShouldCreateConfigurationWithSubdomainForProduction(t *testing.T) {
 	environment := configuration.Production()
 	subdomain := "1234prod"
 
-	subdomain_env := configuration.NewEnvironmentSubdomain(environment, subdomain)
+	subdomain_env, err := configuration.NewEnvironmentSubdomain(environment, subdomain)
+	assert.Nil(t, err)
 	config := configuration.NewConfigurationWithSubdomain(credentials, environment, subdomain_env, &http.Client{}, nil)
 
 	assert.NotNil(t, config)

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -36,7 +36,7 @@ func TestShouldCreateConfigurationWithSubdomain(t *testing.T) {
 		t.Run("Should create configuration with subdomain "+tc.subdomain, func(t *testing.T) {
 			subdomain, err := configuration.NewEnvironmentSubdomain(environment, tc.subdomain)
 			assert.Nil(t, err)
-			config := configuration.NewConfigurationWithSubdomain(credentials, environment, subdomain, &http.Client{}, nil)
+			config := configuration.NewConfigurationWithSubdomain(credentials, nil, environment, subdomain, &http.Client{}, nil)
 
 			assert.NotNil(t, config)
 			assert.Equal(t, tc.expectedApiUrl, config.EnvironmentSubdomain.ApiUrl)
@@ -68,7 +68,7 @@ func TestShouldCreateConfigurationWithSubdomainForProduction(t *testing.T) {
 
 	subdomain_env, err := configuration.NewEnvironmentSubdomain(environment, subdomain)
 	assert.Nil(t, err)
-	config := configuration.NewConfigurationWithSubdomain(credentials, environment, subdomain_env, &http.Client{}, nil)
+	config := configuration.NewConfigurationWithSubdomain(credentials, nil, environment, subdomain_env, &http.Client{}, nil)
 
 	assert.NotNil(t, config)
 	assert.Equal(t, "https://1234prod.api.checkout.com", config.EnvironmentSubdomain.ApiUrl)

--- a/test/default_sdk_api_test.go
+++ b/test/default_sdk_api_test.go
@@ -17,6 +17,10 @@ func TestDefaultCheckoutSdks(t *testing.T) {
 		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
 		WithPublicKey(os.Getenv("CHECKOUT_DEFAULT_PUBLIC_KEY")).
 		WithEnvironment(configuration.Sandbox()).
+		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+		// so the token request would come back invalid_client. Opting out explicitly until
+		// they are.
+		WithLegacyDomain().
 		Build()
 
 	var defaultApiSubdomain, _ = checkout.Builder().
@@ -32,6 +36,7 @@ func TestDefaultCheckoutSdks(t *testing.T) {
 		WithSecretKey("error").
 		WithPublicKey("error").
 		WithEnvironment(configuration.Sandbox()).
+		WithLegacyDomain().
 		Build()
 
 	cases := []struct {
@@ -68,4 +73,67 @@ func TestDefaultCheckoutSdks(t *testing.T) {
 		})
 	}
 
+}
+
+func TestShouldFailWithoutSubdomainOrLegacyDomain(t *testing.T) {
+	api, err := checkout.Builder().
+		StaticKeys().
+		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
+		WithEnvironment(configuration.Sandbox()).
+		Build()
+
+	assert.Nil(t, api)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "environment subdomain is required")
+}
+
+func TestShouldFailWithBothSubdomainAndLegacyDomain(t *testing.T) {
+	api, err := checkout.Builder().
+		StaticKeys().
+		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
+		WithEnvironment(configuration.Sandbox()).
+		WithEnvironmentSubdomain("1234doma").
+		WithLegacyDomain().
+		Build()
+
+	assert.Nil(t, api)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "cannot both be set")
+}
+
+func TestShouldFailWithInvalidSubdomain(t *testing.T) {
+	api, err := checkout.Builder().
+		StaticKeys().
+		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
+		WithEnvironment(configuration.Sandbox()).
+		WithEnvironmentSubdomain("not a subdomain").
+		Build()
+
+	assert.Nil(t, api)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid environment subdomain")
+}
+
+func TestShouldCreateSdkWithLegacyDomain(t *testing.T) {
+	api, err := checkout.Builder().
+		StaticKeys().
+		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
+		WithPublicKey(os.Getenv("CHECKOUT_DEFAULT_PUBLIC_KEY")).
+		WithEnvironment(configuration.Sandbox()).
+		WithLegacyDomain().
+		Build()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, api)
+}
+
+func TestShouldCreatePreviousSdkWithoutSubdomain(t *testing.T) {
+	api, err := checkout.Builder().Previous().
+		WithSecretKey(os.Getenv("CHECKOUT_PREVIOUS_SECRET_KEY")).
+		WithPublicKey(os.Getenv("CHECKOUT_PREVIOUS_PUBLIC_KEY")).
+		WithEnvironment(configuration.Sandbox()).
+		Build()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, api)
 }

--- a/test/default_sdk_api_test.go
+++ b/test/default_sdk_api_test.go
@@ -17,10 +17,7 @@ func TestDefaultCheckoutSdks(t *testing.T) {
 		WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
 		WithPublicKey(os.Getenv("CHECKOUT_DEFAULT_PUBLIC_KEY")).
 		WithEnvironment(configuration.Sandbox()).
-		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-		// so the token request would come back invalid_client. Opting out explicitly until
-		// they are.
-		WithLegacyDomain().
+		WithEnvironmentSubdomain(os.Getenv("CHECKOUT_MERCHANT_SUBDOMAIN")).
 		Build()
 
 	var defaultApiSubdomain, _ = checkout.Builder().

--- a/test/issuing_base_test.go
+++ b/test/issuing_base_test.go
@@ -61,6 +61,10 @@ func buildIssuingClientApi() *nas.Api {
 				configuration.IssuingCardMgmt,
 				configuration.IssuingControlsRead,
 				configuration.IssuingControlsWrite}).
+			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+			// so the token request would come back invalid_client. Opting out explicitly until
+			// they are.
+			WithLegacyDomain().
 			Build()
 	}
 

--- a/test/issuing_base_test.go
+++ b/test/issuing_base_test.go
@@ -61,9 +61,8 @@ func buildIssuingClientApi() *nas.Api {
 				configuration.IssuingCardMgmt,
 				configuration.IssuingControlsRead,
 				configuration.IssuingControlsWrite}).
-			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-			// so the token request would come back invalid_client. Opting out explicitly until
-			// they are.
+			// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+			// come back invalid_client. Opting out explicitly until they are provisioned.
 			WithLegacyDomain().
 			Build()
 	}

--- a/test/issuing_base_test.go
+++ b/test/issuing_base_test.go
@@ -52,8 +52,8 @@ func buildIssuingClientApi() *nas.Api {
 	if issuingClientApi == nil {
 		issuingClientApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{
 				configuration.Vault,

--- a/test/issuing_base_test.go
+++ b/test/issuing_base_test.go
@@ -52,8 +52,8 @@ func buildIssuingClientApi() *nas.Api {
 	if issuingClientApi == nil {
 		issuingClientApi, _ = checkout.Builder().OAuth().
 			WithClientCredentials(
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
-				os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET")).
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
+				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes([]string{
 				configuration.Vault,

--- a/test/issuing_cardholdertoken_test.go
+++ b/test/issuing_cardholdertoken_test.go
@@ -27,8 +27,8 @@ func TestRequestCardholderTokenWithContext(t *testing.T) {
 			name: "when request is correct then return cardholder token",
 			request: cardholdertokens.CardholderTokenRequest{
 				GrantType:    "client_credentials",
-				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
-				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET"),
+				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
+				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET"),
 				CardholderId: created.Id,
 			},
 			checker: func(response *cardholdertokens.CardholderTokenResponse, err error) {
@@ -44,8 +44,8 @@ func TestRequestCardholderTokenWithContext(t *testing.T) {
 			name: "when single_use is true then return single-use cardholder token",
 			request: cardholdertokens.CardholderTokenRequest{
 				GrantType:    "client_credentials",
-				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
-				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET"),
+				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
+				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET"),
 				CardholderId: created.Id,
 				SingleUse:    true,
 			},

--- a/test/issuing_cardholdertoken_test.go
+++ b/test/issuing_cardholdertoken_test.go
@@ -27,8 +27,8 @@ func TestRequestCardholderTokenWithContext(t *testing.T) {
 			name: "when request is correct then return cardholder token",
 			request: cardholdertokens.CardholderTokenRequest{
 				GrantType:    "client_credentials",
-				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET"),
+				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
+				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET"),
 				CardholderId: created.Id,
 			},
 			checker: func(response *cardholdertokens.CardholderTokenResponse, err error) {
@@ -44,8 +44,8 @@ func TestRequestCardholderTokenWithContext(t *testing.T) {
 			name: "when single_use is true then return single-use cardholder token",
 			request: cardholdertokens.CardholderTokenRequest{
 				GrantType:    "client_credentials",
-				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET"),
+				ClientId:     os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID"),
+				ClientSecret: os.Getenv("CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET"),
 				CardholderId: created.Id,
 				SingleUse:    true,
 			},

--- a/test/oauth_sdk_api_test.go
+++ b/test/oauth_sdk_api_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -83,4 +85,37 @@ func TestOauthCheckoutSdkWithSubdomain(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "invalid_client")
+}
+
+func TestOauthShouldFailWithAuthorizationUriAndSubdomain(t *testing.T) {
+	api, err := checkout.Builder().
+		OAuth().
+		WithClientCredentials("client_id", "client_secret").
+		WithAuthorizationUri("https://access.sandbox.checkout.com/connect/token").
+		WithEnvironment(configuration.Sandbox()).
+		WithEnvironmentSubdomain("1234doma").
+		Build()
+
+	assert.Nil(t, api)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "authorization URI and environment subdomain cannot both be set")
+}
+
+func TestOauthShouldBuildWithAuthorizationUriAndLegacyDomain(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"token","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	api, err := checkout.Builder().
+		OAuth().
+		WithClientCredentials("client_id", "client_secret").
+		WithAuthorizationUri(tokenServer.URL).
+		WithEnvironment(configuration.Sandbox()).
+		WithLegacyDomain().
+		Build()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, api)
 }

--- a/test/oauth_sdk_api_test.go
+++ b/test/oauth_sdk_api_test.go
@@ -18,17 +18,11 @@ func TestOauthCheckoutSdks(t *testing.T) {
 			os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
 			os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 		WithEnvironment(configuration.Sandbox()).
+		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+		// so the token request would come back invalid_client. Opting out explicitly until
+		// they are.
+		WithLegacyDomain().
 		Build()
-
-	// Not ready yet to tests with subdomains
-	// var oauthApiSubdomain, _ = checkout.Builder().
-	// 	OAuth().
-	// 	WithClientCredentials(
-	// 		os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
-	// 		os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
-	// 	WithEnvironment(configuration.Sandbox()).
-	// 	WithEnvironmentSubdomain("123dmain").
-	// 	Build()
 
 	var oauthApiBad, _ = checkout.Builder().
 		OAuth().
@@ -36,6 +30,7 @@ func TestOauthCheckoutSdks(t *testing.T) {
 			"error",
 			"error").
 		WithEnvironment(configuration.Sandbox()).
+		WithLegacyDomain().
 		Build()
 
 	cases := []struct {

--- a/test/oauth_sdk_api_test.go
+++ b/test/oauth_sdk_api_test.go
@@ -18,9 +18,8 @@ func TestOauthCheckoutSdks(t *testing.T) {
 			os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_ID"),
 			os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 		WithEnvironment(configuration.Sandbox()).
-		// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-		// so the token request would come back invalid_client. Opting out explicitly until
-		// they are.
+		// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+		// come back invalid_client. Opting out explicitly until they are provisioned.
 		WithLegacyDomain().
 		Build()
 

--- a/test/sandbox_test_fixture_test.go
+++ b/test/sandbox_test_fixture_test.go
@@ -60,6 +60,10 @@ func DefaultApi() *nas.Api {
 			WithEnvironment(configuration.Sandbox()).
 			WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
 			WithPublicKey(os.Getenv("CHECKOUT_DEFAULT_PUBLIC_KEY")).
+			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
+			// so the token request would come back invalid_client. Opting out explicitly until
+			// they are.
+			WithLegacyDomain().
 			Build()
 	}
 	return defaultApi
@@ -78,6 +82,7 @@ func OAuthApi() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes(getOAuthScopes()).
+			WithLegacyDomain().
 			Build()
 	}
 	return oauthApi

--- a/test/sandbox_test_fixture_test.go
+++ b/test/sandbox_test_fixture_test.go
@@ -60,10 +60,7 @@ func DefaultApi() *nas.Api {
 			WithEnvironment(configuration.Sandbox()).
 			WithSecretKey(os.Getenv("CHECKOUT_DEFAULT_SECRET_KEY")).
 			WithPublicKey(os.Getenv("CHECKOUT_DEFAULT_PUBLIC_KEY")).
-			// The sandbox OAuth clients are not provisioned for the merchant-specific subdomain,
-			// so the token request would come back invalid_client. Opting out explicitly until
-			// they are.
-			WithLegacyDomain().
+			WithEnvironmentSubdomain(os.Getenv("CHECKOUT_MERCHANT_SUBDOMAIN")).
 			Build()
 	}
 	return defaultApi
@@ -82,6 +79,8 @@ func OAuthApi() *nas.Api {
 				os.Getenv("CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET")).
 			WithEnvironment(configuration.Sandbox()).
 			WithScopes(getOAuthScopes()).
+			// The sandbox OAuth clients lack subdomain provisioning, so the token request would
+			// come back invalid_client. Opting out explicitly until they are provisioned.
 			WithLegacyDomain().
 			Build()
 	}


### PR DESCRIPTION
## Summary

Makes the merchant-specific subdomain (MSSD) mandatory. Callers must now call `WithEnvironmentSubdomain(...)`, or explicitly opt out with the new `WithLegacyDomain()`, which carries a `Deprecated:` doc comment from its first release so `staticcheck` (SA1019) and editors flag it. Setting both, or neither, makes `Build()` return a `CheckoutArgumentError`. MSSD is no longer beta and non-MSSD usage will be deprecated, so the previous silent fallback to `api.checkout.com` had to go.

**The module path deliberately stays on `/v2` in this PR.** Go needs `/v3` declared before a `v3.0.0` tag can exist, not before this change can be reviewed, so that rename goes in its own mechanical PR at release time. Putting it here would add 848 import rewrites across 293 files and bury a 12-file behavioural change for no review value.

One ordering note for whoever cuts the release: do not tag a `v2.x` between merging this and the rename, because `master` would then carry a breaking change under a `v2` module path. Tagged releases are unaffected either way; only consumers tracking `master` would see it.

## Changes

- `configuration/sdk_builder.go` — `EnvironmentSubdomain *EnvironmentSubdomain` becomes `Subdomain string` + `UseLegacyDomain bool`; new `GetEnvironmentSubdomain()` resolving the URLs at build time, so `WithEnvironmentSubdomain` no longer has to be called after `WithEnvironment`; new `ValidateEnvironmentSettings(requiresSubdomain bool)`
- `configuration/environment.go` — `NewEnvironmentSubdomain` returns `(*EnvironmentSubdomain, error)` and `createUrlWithSubdomain` errors on an invalid subdomain instead of returning the URL unchanged
- `nas/checkout_default_sdk_builder.go`, `nas/checkout_oauth_sdk_builder.go`, `abc/checkout_previous_sdk_builder.go` — new `WithLegacyDomain()`, validation at the top of `Build()`; Previous/ABC exempted with `ValidateEnvironmentSettings(false)`
- `test/configuration_api_test.go` — the bad-subdomain table now asserts the error instead of the silent fallback
- `test/default_sdk_api_test.go` — covers all four combinations, an invalid subdomain, and the Previous exemption
- `test/sandbox_test_fixture_test.go` and the accounts, issuing, telemetry and sdk-api tests — every client the suite builds now chooses a domain

### Migration for callers

Set the subdomain, or call `WithLegacyDomain()` as a temporary measure. When the `/v3` rename lands at release time, consumers will also have to update their import paths.

## Verification

`go build ./...` and `go vet ./...` clean. The configuration and SDK-builder tests pass.

Note: the repo's Go 1.14 toolchain cannot run test binaries on an arm64 Mac (`missing LC_UUID`, which fails identically on master), so the suite was run with Go 1.18 locally. CI covers both 1.14 and 1.18.
## API Reference

- https://api-reference.checkout.com/#section/Base-URLs
- https://www.checkout.com/docs/developer-resources/api/api-endpoints

## Breaking changes

Yes, two. This needs a major release, classified and versioned when the release is cut.

1. The merchant-specific subdomain is mandatory for the Default and DefaultOAuth platforms. Code that omitted it and relied on the implicit fallback to `api.checkout.com` / `access.checkout.com` now fails at client construction. Migration: set the subdomain, or use the legacy-domain opt-out as a temporary measure. The Previous (ABC) platform is unaffected.
2. An invalid subdomain now fails instead of being silently ignored. Callers passing a malformed value keep working against the shared host today; after this change they fail fast. This one is easy to miss because it is not what the ticket asked for, so it needs its own line in the release notes.

## README

Updated in this PR: a "Subdomain value" section above the Default example, the subdomain added to the configuration samples, and a "Legacy domain (emergency use only)" section at the bottom.

## Notes

The suite routes every client it builds through a single helper that uses the shared hosts. Applying the merchant-specific subdomain there looked better, since it is the path merchants are being moved to, but the sandbox OAuth clients are not provisioned for it: .NET CI failed 224 integration tests with `invalid_client` when the token request went to `{subdomain}.access.sandbox.checkout.com`. Binding those OAuth clients to the subdomain is a platform task and should land before merchants are told the subdomain is mandatory.

Reference implementation: [checkout-sdk-net#590](https://github.com/checkout/checkout-sdk-net/pull/590). Tracked as [INT-1688](https://checkout.atlassian.net/browse/INT-1688).


[INT-1688]: https://checkout.atlassian.net/browse/INT-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

No version bump here: that happens on master when the release is cut, per the release workflow.

---

**Review follow-ups (2026-08-31)**

Breaking changes, complete list:
1. The merchant-specific subdomain is now required; building without it (and without the legacy opt-out) throws.
2. An invalid subdomain now throws instead of being silently ignored.

Behaviour note: host resolution is now deferred to build time, which also fixes a latent order-dependence bug where setting the subdomain before the environment produced the wrong host.

Deprecation signal: compile-time (Deprecated comment recognized by staticcheck).

**Option A applied (2026-08-31):** an explicit OAuth authorization URI and the environment subdomain are now mutually exclusive at build time; the README OAuth example no longer sets an authorization URI, subdomain-only is the documented path.
