### PR TITLE
feat: add InstrumentDocumentType with bank_statement

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -30,6 +30,8 @@ const (
 
 type (
 	InstrumentDocument struct {
+		// Type accepts only bank_statement. Use common.BankStatement rather than a literal.
+		// Left as a string so existing callers keep compiling.
 		Type   string `json:"type,omitempty"`
 		FileId string `json:"file_id,omitempty"`
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -107,6 +107,19 @@ const (
 	ElectoralId          DocumentType = "electoral_id"
 )
 
+// InstrumentDocumentType is the type of the legal document that verifies a bank account when
+// creating a payment instrument.
+//
+// Deliberately separate from DocumentType, which lists identity documents (passport, national
+// identity card, driving license). The API models the bank account document type as its own
+// enum whose only accepted value is bank_statement, so offering it alongside the identity
+// documents would suggest it is valid where the API rejects it, and vice versa.
+type InstrumentDocumentType string
+
+const (
+	BankStatement InstrumentDocumentType = "bank_statement"
+)
+
 type AccountHolderIdentificationType string
 
 const (

--- a/common/instrument_document_type_test.go
+++ b/common/instrument_document_type_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Reported internally against the PHP SDK: bank_statement was missing everywhere. It is the
+// document type for the bank account behind a payment instrument, not an identity document.
+func TestInstrumentDocumentType(t *testing.T) {
+	t.Run("should expose bank_statement for instrument documents", func(t *testing.T) {
+		assert.Equal(t, InstrumentDocumentType("bank_statement"), BankStatement)
+	})
+
+	t.Run("should serialize to the value the API accepts", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{"type": BankStatement})
+
+		assert.Nil(t, err)
+		assert.Equal(t, `{"type":"bank_statement"}`, string(body))
+	})
+
+	// bank_statement belongs to the instrument document enum, not the identity one. This is what
+	// stops the two being merged the next time someone reports it missing from DocumentType.
+	t.Run("should keep bank_statement out of the identity document type", func(t *testing.T) {
+		identity := []DocumentType{
+			PassportDocumentType,
+			NationalIdentityCard,
+			DrivingLicense,
+			CitizenCard,
+			ResidencePermit,
+			ElectoralId,
+		}
+
+		assert.NotContains(t, identity, DocumentType(BankStatement))
+	})
+}


### PR DESCRIPTION
## What

Adds `InstrumentDocumentType` with the single value `bank_statement`, the document type for the bank account behind a platforms payment instrument.

Reported internally: the value is documented in the API reference but missing from the SDK, and it is blocking a merchant. Verified against the spec, where that document type is a single-value enum whose only accepted value (and default) is `bank_statement`.

## Why a separate type instead of adding the value to the existing document type

The existing document type lists identity documents (passport, national identity card, driving license) and is used for entity onboarding. The API models the bank account document type as its own enum. Adding `bank_statement` alongside the identity values would offer it in every place the API rejects it, and would equally suggest the identity values are accepted on an instrument document, where they are not.

## Tests

One of the tests asserts `bank_statement` is **not** in the identity document type. That is deliberate: it is what stops the two being merged the next time someone reports the value as missing from the identity enum.

## Not breaking

Purely additive. No existing constant, field or signature changes.

Refs INT-1691.

## Go note

`InstrumentDocument.Type` stays a `string` rather than becoming a typed field, so callers already passing a literal keep compiling. The doc comment points at `common.BankStatement`.