### PR TITLE
fix: add merchant_id and actually deserialize tos_accepted_time on Google Pay enrollment

### DIFF
--- a/payments/googlepay/googlepay.go
+++ b/payments/googlepay/googlepay.go
@@ -30,9 +30,19 @@ type RegisterDomainRequest struct {
 	WebDomain string `json:"web_domain"`
 }
 
+// CreateEnrollmentResponse is the body returned by POST /googlepay/enrollments.
+//
+// The API returns merchant_id, tos_accepted_time and state. The spec declares only
+// tosAcceptedTime (camelCase) and state, with additionalProperties false, so this struct was
+// generated from a wrong schema: merchant_id was missing, and TosAcceptedTime carried the
+// camelCase name, which never matches the real payload and so was always nil. Reported by a
+// merchant. The spec is being fixed separately; until then this struct follows the live API.
 type CreateEnrollmentResponse struct {
-	HttpMetadata    common.HttpMetadata
-	TosAcceptedTime *time.Time      `json:"tosAcceptedTime"`
+	HttpMetadata common.HttpMetadata
+	// MerchantId is the Google Pay merchant identifier assigned to the entity, needed to
+	// initialise Google Pay on the client.
+	MerchantId      string          `json:"merchant_id"`
+	TosAcceptedTime *time.Time      `json:"tos_accepted_time"`
 	State           EnrollmentState `json:"state"`
 }
 

--- a/payments/googlepay/googlepay_test.go
+++ b/payments/googlepay/googlepay_test.go
@@ -1,0 +1,81 @@
+package googlepay
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The body a real POST /googlepay/enrollments returns in sandbox. Used instead of the swagger
+// example because the swagger example is the thing that was wrong: it omits merchant_id and
+// names the timestamp tosAcceptedTime.
+const realEnrollmentResponse = `{
+	"merchant_id": "12345678901234567890",
+	"tos_accepted_time": "2026-08-13T09:12:41Z",
+	"state": "ACTIVE"
+}`
+
+func TestCreateEnrollmentResponseDeserialization(t *testing.T) {
+	t.Run("should deserialize the real enrollment response", func(t *testing.T) {
+		var response CreateEnrollmentResponse
+
+		err := json.Unmarshal([]byte(realEnrollmentResponse), &response)
+
+		assert.Nil(t, err)
+		assert.Equal(t, "12345678901234567890", response.MerchantId)
+		assert.NotNil(t, response.TosAcceptedTime)
+		assert.Equal(t, time.Date(2026, 8, 13, 9, 12, 41, 0, time.UTC), response.TosAcceptedTime.UTC())
+		assert.Equal(t, Active, response.State)
+	})
+
+	// This is the regression that matters most in Go. The field was tagged tosAcceptedTime, which
+	// never matches the real payload, so it came back nil for every caller while looking correct.
+	t.Run("should populate tos_accepted_time, which the camelCase tag never matched", func(t *testing.T) {
+		var response CreateEnrollmentResponse
+
+		err := json.Unmarshal([]byte(realEnrollmentResponse), &response)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, response.TosAcceptedTime, "tos_accepted_time must deserialize, it was silently nil before")
+	})
+
+	// merchant_id is what the caller needs to initialise Google Pay on the client, so losing it
+	// is the whole defect.
+	t.Run("should not silently drop merchant_id", func(t *testing.T) {
+		var response CreateEnrollmentResponse
+
+		err := json.Unmarshal([]byte(realEnrollmentResponse), &response)
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, response.MerchantId)
+	})
+
+	t.Run("should leave the fields at their zero value when absent", func(t *testing.T) {
+		var response CreateEnrollmentResponse
+
+		err := json.Unmarshal([]byte(`{"state":"INACTIVE"}`), &response)
+
+		assert.Nil(t, err)
+		assert.Empty(t, response.MerchantId)
+		assert.Nil(t, response.TosAcceptedTime)
+		assert.Equal(t, Inactive, response.State)
+	})
+
+	t.Run("should marshal the field names the API uses", func(t *testing.T) {
+		tosAcceptedTime := time.Date(2026, 8, 13, 9, 12, 41, 0, time.UTC)
+		response := CreateEnrollmentResponse{
+			MerchantId:      "12345678901234567890",
+			TosAcceptedTime: &tosAcceptedTime,
+			State:           Active,
+		}
+
+		body, err := json.Marshal(response)
+
+		assert.Nil(t, err)
+		assert.Contains(t, string(body), `"merchant_id":"12345678901234567890"`)
+		assert.Contains(t, string(body), `"tos_accepted_time":"2026-08-13T09:12:41Z"`)
+		assert.NotContains(t, string(body), "tosAcceptedTime")
+	})
+}


### PR DESCRIPTION
## What

Two fixes in the Google Pay enrollment response, from the same wrong schema. **This one is not just an addition like the .NET and Java PRs: there is a live bug here.**

## 1. `tos_accepted_time` never deserialized

`TosAcceptedTime` was tagged `json:"tosAcceptedTime"`. The API sends `tos_accepted_time`, so that tag never matched: the field came back `nil` for **every caller**, silently, while looking correct in the struct.

Not part of the original report. Found while verifying it.

.NET and Java were unaffected because their serializers map snake_case globally. This SDK carries explicit tags, so the wrong name in the spec became a real bug.

## 2. `merchant_id` was missing

Reported internally on behalf of a merchant. It is what the caller needs to initialise Google Pay on the client.

## Root cause is the spec

`GooglePayEnrollmentResponse` declares only `tosAcceptedTime` (camelCase) and `state`, omits `merchant_id`, and sets `additionalProperties: false`. The real 201 from `POST /googlepay/enrollments` returns:

```json
{
  "merchant_id": "12345678901234567890",
  "tos_accepted_time": "2026-08-13T09:12:41Z",
  "state": "ACTIVE"
}
```

**The spec fix is being raised separately and is the actual fix**: until it lands, the next regeneration reintroduces both problems.

## Tests

Against the real sandbox body, not the swagger example, since the swagger example is what was wrong. One subtest asserts specifically that the timestamp now populates, because that is the regression rather than the addition. Another asserts the marshalled JSON no longer contains `tosAcceptedTime` at all.

5 subtests green, `go vet` clean, all `payments/...` packages passing on 1.14 and 1.18.

## Breaking?

No. The JSON tag changes, but the old tag matched nothing the API sends, so no caller was receiving a value that stops arriving. Anyone reading `TosAcceptedTime` gets a populated value where they previously got `nil`.

Refs INT-1690.