### PR TITLE
feature/INT-1693 - Payment sessions default values defect fix

### DIFF
--- a/payments/sessions/capture_defaults_test.go
+++ b/payments/sessions/capture_defaults_test.go
@@ -1,0 +1,142 @@
+package payment_sessions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v2/common"
+	"github.com/checkout/checkout-sdk-go/v2/payments"
+	"github.com/checkout/checkout-sdk-go/v2/payments/nas"
+)
+
+// Verifies that capture is omitted from every payment session request unless the caller sets it.
+//
+// Capture was previously declared as a non-pointer bool without omitempty, so a zero-value struct
+// serialized "capture":false. On session creation that silently disabled auto-capture, contradicting
+// the API default of true. On submit it overwrote the value provided when the session was created.
+
+func TestPaymentSessionsRequest_OmitsCaptureWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentSessionsRequest{})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "capture")
+}
+
+func TestPaymentSessionsWithPaymentRequest_OmitsCaptureWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentSessionsWithPaymentRequest{SessionData: "SD"})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "capture")
+}
+
+func TestSubmitPaymentSessionRequest_OmitsCaptureWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(SubmitPaymentSessionRequest{SessionData: "SD"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, `{"session_data":"SD"}`, string(marshalled))
+}
+
+// Verifies capture is still fully expressible in both directions.
+
+func TestSubmitPaymentSessionRequest_SendsCaptureFalseWhenExplicitlySet(t *testing.T) {
+	capture := false
+
+	marshalled, err := json.Marshal(SubmitPaymentSessionRequest{
+		SessionData: "SD",
+		Capture:     &capture,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"capture":false`)
+}
+
+func TestSubmitPaymentSessionRequest_SendsCaptureTrueWhenExplicitlySet(t *testing.T) {
+	capture := true
+
+	marshalled, err := json.Marshal(SubmitPaymentSessionRequest{
+		SessionData: "SD",
+		Capture:     &capture,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"capture":true`)
+}
+
+func TestPaymentSessionsRequest_SendsCaptureFalseWhenExplicitlySet(t *testing.T) {
+	capture := false
+
+	marshalled, err := json.Marshal(PaymentSessionsRequest{
+		Amount:   1000,
+		Currency: common.GBP,
+		Capture:  &capture,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"capture":false`)
+}
+
+// Verifies the fields added to close the gaps found while auditing these three request bodies
+// against the swagger.
+
+func TestSubmitPaymentSessionRequest_SerializesAmountAllocations(t *testing.T) {
+	marshalled, err := json.Marshal(SubmitPaymentSessionRequest{
+		SessionData: "SD",
+		AmountAllocations: []common.AmountAllocations{
+			{
+				Id:     "ent_abcdefghijklmnopqrstuvwxyz",
+				Amount: 1000,
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"amount_allocations":`)
+	assert.Contains(t, string(marshalled), `"id":"ent_abcdefghijklmnopqrstuvwxyz"`)
+}
+
+func TestPaymentSessionsWithPaymentRequest_SerializesAuthorizationTypeAndPaymentPlan(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentSessionsWithPaymentRequest{
+		SessionData:       "SD",
+		AuthorizationType: nas.EstimatedAuthorizationType,
+		PaymentPlan: &payments.PaymentPlan{
+			AmountVariability:   payments.FixedAVT,
+			DaysBetweenPayments: 28,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"authorization_type":"Estimated"`)
+	assert.Contains(t, string(marshalled), `"payment_plan":`)
+	assert.Contains(t, string(marshalled), `"days_between_payments":28`)
+}
+
+func TestPaymentSessionsWithPaymentRequest_OmitsNewFieldsWhenUnset(t *testing.T) {
+	marshalled, err := json.Marshal(PaymentSessionsWithPaymentRequest{SessionData: "SD"})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "authorization_type")
+	assert.NotContains(t, string(marshalled), "payment_plan")
+}
+
+func TestSubmitPaymentSessionRequest_UnmarshalsCapture(t *testing.T) {
+	var request SubmitPaymentSessionRequest
+
+	err := json.Unmarshal([]byte(`{"session_data":"SD","capture":false}`), &request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "SD", request.SessionData)
+	assert.NotNil(t, request.Capture)
+	assert.False(t, *request.Capture)
+}
+
+func TestSubmitPaymentSessionRequest_UnmarshalsDocumentedExample(t *testing.T) {
+	var request SubmitPaymentSessionRequest
+
+	err := json.Unmarshal([]byte(`{"session_data":"{SESSION_DATA_FROM_FLOW}","3ds":{"enabled":true}}`), &request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "{SESSION_DATA_FROM_FLOW}", request.SessionData)
+	assert.Nil(t, request.Capture, "the documented example does not carry capture")
+}

--- a/payments/sessions/sessions.go
+++ b/payments/sessions/sessions.go
@@ -94,7 +94,7 @@ type (
 		Locale                     payments.LocalType                       `json:"locale,omitempty"`
 		ThreeDsRequest             *payments.ThreeDsRequestFlowHostedLinks  `json:"3ds,omitempty"`
 		Sender                     *nas.Sender                              `json:"sender,omitempty"`
-		Capture                    bool                                     `json:"capture"`
+		Capture                    *bool                                    `json:"capture,omitempty"`
 		CaptureOn                  *time.Time                               `json:"capture_on,omitempty"`
 		ExpiresOn                  *time.Time                               `json:"expires_on,omitempty"`
 		EnabledPaymentMethods      []PaymentMethodsType                     `json:"enabled_payment_methods,omitempty"`
@@ -149,8 +149,10 @@ type (
 		Locale                     payments.LocalType                       `json:"locale,omitempty"`
 		ThreeDsRequest             *payments.ThreeDsRequestFlowHostedLinks  `json:"3ds,omitempty"`
 		Sender                     *nas.Sender                              `json:"sender,omitempty"`
-		Capture                    bool                                     `json:"capture"`
+		Capture                    *bool                                    `json:"capture,omitempty"`
 		CaptureOn                  *time.Time                               `json:"capture_on,omitempty"`
+		AuthorizationType          nas.AuthorizationType                    `json:"authorization_type,omitempty"`
+		PaymentPlan                *payments.PaymentPlan                    `json:"payment_plan,omitempty"`
 	}
 
 	SubmitPaymentSessionRequest struct {
@@ -175,9 +177,10 @@ type (
 		ProcessingChannelId        string                               `json:"processing_channel_id,omitempty"`
 		Metadata                   map[string]interface{}               `json:"metadata,omitempty"`
 		Sender                     *nas.Sender                          `json:"sender,omitempty"`
-		Capture                    bool                                 `json:"capture"`
+		Capture                    *bool                                `json:"capture,omitempty"`
 		CaptureOn                  *time.Time                           `json:"capture_on,omitempty"`
 		Processing                 *payments.ProcessingSettings         `json:"processing,omitempty"`
+		AmountAllocations          []common.AmountAllocations           `json:"amount_allocations,omitempty"`
 	}
 
 	// Response structures for payment session submit/complete endpoints


### PR DESCRIPTION
This pull request fixes a defect in the payment sessions default values, updates the payment session request models to better align with the API specification and ensures correct JSON serialization behavior, especially for the `capture` field. It also adds comprehensive tests to verify these behaviors and introduces several new fields to close gaps found during an audit against the API documentation.

**Model and Serialization Improvements:**

* Changed the `Capture` field in `PaymentSessionsRequest`, `PaymentSessionsWithPaymentRequest`, and `SubmitPaymentSessionRequest` from a non-pointer `bool` to a pointer `*bool` with `omitempty`, ensuring the field is only serialized when explicitly set and does not override API defaults unintentionally. [[1]](diffhunk://#diff-b919c728284c6d02e248bfa25cd892d6232eb30bccf9e414749698daf089c0c3L97-R97) [[2]](diffhunk://#diff-b919c728284c6d02e248bfa25cd892d6232eb30bccf9e414749698daf089c0c3L178-R183)

**Field Additions for API Coverage:**

* Added `AuthorizationType` and `PaymentPlan` fields to `PaymentSessionsWithPaymentRequest` to match the API specification.
* Added `AmountAllocations` field to `SubmitPaymentSessionRequest` for improved API compatibility.

**Test Coverage:**

* Introduced a comprehensive test suite in `capture_defaults_test.go` to verify that:
  - The `capture` field is omitted from JSON unless explicitly set.
  - The new fields (`authorization_type`, `payment_plan`, `amount_allocations`) are correctly serialized and omitted when unset.
  - Both marshaling and unmarshaling of the `capture` field work as intended, including for documented API examples.