### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/payments/payments.go
+++ b/payments/payments.go
@@ -924,6 +924,8 @@ type (
 	}
 
 	VoidRequest struct {
+		// Amount to void (min 0, max 9999999999). If not specified, the full payment amount is voided.
+		Amount    int64                  `json:"amount,omitempty"`
 		Reference string                 `json:"reference,omitempty"`
 		Metadata  map[string]interface{} `json:"metadata,omitempty"`
 	}

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -924,8 +924,10 @@ type (
 	}
 
 	VoidRequest struct {
-		// Amount to void (min 0, max 9999999999). If not specified, the full payment amount is voided.
-		Amount    int64                  `json:"amount,omitempty"`
+		// Amount to void (min 0, max 9999999999). If not specified, the full payment
+		// amount is voided. A pointer so an explicit 0, which the spec allows, is
+		// distinguishable from the field not being set.
+		Amount    *int64                 `json:"amount,omitempty"`
 		Reference string                 `json:"reference,omitempty"`
 		Metadata  map[string]interface{} `json:"metadata,omitempty"`
 	}

--- a/payments/void_request_test.go
+++ b/payments/void_request_test.go
@@ -1,0 +1,41 @@
+package payments
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies VoidRequest (POST /payments/{id}/voids) marshalling: amount serializes
+// under the "amount" key, and an unset amount is absent from the JSON body so
+// existing full-void callers keep sending the same request.
+func TestVoidRequest_MarshalAmount(t *testing.T) {
+	request := VoidRequest{
+		Amount:    6540,
+		Reference: "ORD-5023-4E89",
+	}
+
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &body))
+	assert.Equal(t, float64(6540), body["amount"])
+	assert.Equal(t, "ORD-5023-4E89", body["reference"])
+}
+
+func TestVoidRequest_MarshalWithoutAmount(t *testing.T) {
+	request := VoidRequest{
+		Reference: "ORD-5023-4E89",
+	}
+
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &body))
+	_, present := body["amount"]
+	assert.False(t, present)
+	assert.Equal(t, map[string]interface{}{"reference": "ORD-5023-4E89"}, body)
+}

--- a/payments/void_request_test.go
+++ b/payments/void_request_test.go
@@ -11,8 +11,9 @@ import (
 // under the "amount" key, and an unset amount is absent from the JSON body so
 // existing full-void callers keep sending the same request.
 func TestVoidRequest_MarshalAmount(t *testing.T) {
+	amount := int64(6540)
 	request := VoidRequest{
-		Amount:    6540,
+		Amount:    &amount,
 		Reference: "ORD-5023-4E89",
 	}
 
@@ -38,4 +39,25 @@ func TestVoidRequest_MarshalWithoutAmount(t *testing.T) {
 	_, present := body["amount"]
 	assert.False(t, present)
 	assert.Equal(t, map[string]interface{}{"reference": "ORD-5023-4E89"}, body)
+}
+
+// The spec allows an explicit zero amount (minimum 0) and an entirely empty
+// request body (every field optional): both must be expressible, which is why
+// Amount is a pointer rather than a value with omitempty.
+func TestVoidRequest_MarshalExplicitZeroAmount(t *testing.T) {
+	amount := int64(0)
+	request := VoidRequest{Amount: &amount}
+
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &body))
+	assert.Equal(t, float64(0), body["amount"])
+}
+
+func TestVoidRequest_MarshalEmptyRequest(t *testing.T) {
+	data, err := json.Marshal(VoidRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
 }


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.