### PR TITLE
feat(accounts): add ISV payout schedule fields and payment_instrument_id

### DIFF
--- a/accounts/payouts.go
+++ b/accounts/payouts.go
@@ -8,11 +8,22 @@ import (
 	"github.com/checkout/checkout-sdk-go/v2/errors"
 )
 
+// Frequency indicates how often funds should be paid out to a sub-entity.
 type Frequency string
 
 const (
-	Weekly  Frequency = "weekly"
-	Daily   Frequency = "daily"
+	// Weekly pays out on the configured days of the week. SaaS seller (ISV)
+	// sub-entities accept working days only, Monday to Friday: a schedule set
+	// to a Saturday or Sunday is rejected. Standard sub-entities accept any day.
+	Weekly Frequency = "weekly"
+	// Daily pays out every day for standard sub-entities. For SaaS seller (ISV)
+	// sub-entities it runs on working days only, Monday to Friday, with no
+	// payout at weekends, based on the available balance as of 00:00 in the
+	// sub-entity's time zone.
+	Daily Frequency = "daily"
+	// Monthly pays out on the configured days of the month. Standard
+	// sub-entities accept any day from 1 to 28. SaaS seller (ISV) sub-entities
+	// accept only these combinations, in any order: [1], [15], [1, 15] or [1, 16].
 	Monthly Frequency = "monthly"
 )
 
@@ -82,9 +93,23 @@ func (s scheduleFrequencyMonthly) GetSchedule() Frequency {
 
 type (
 	CurrencySchedule struct {
-		Enabled             bool       `json:"enabled,omitempty"`
-		Threshold           int        `json:"threshold,omitempty"`
-		PaymentInstrumentId string     `json:"payment_instrument_id,omitempty"`
+		Enabled   bool `json:"enabled,omitempty"`
+		Threshold int  `json:"threshold,omitempty"`
+		// PaymentInstrumentId is the ID of the platforms payment instrument used
+		// as the payout destination for this schedule. Optional for SaaS seller
+		// (ISV) schedules; if included, it must reference a verified payment
+		// instrument, otherwise the request fails.
+		PaymentInstrumentId string `json:"payment_instrument_id,omitempty"`
+		// BalanceMinimum is the amount, in the minor units of the schedule's
+		// currency, to retain in the sub-entity's available balance. Only the
+		// funds above this are paid out, and no payout is generated if there are
+		// none. Defaults to 0 if not set. SaaS seller (ISV) schedules only.
+		BalanceMinimum *int64 `json:"balance_minimum,omitempty"`
+		// CarryForwardEnabled indicates whether to carry forward any balance
+		// below the configured minimum to the next payout. Always returned for
+		// SaaS sellers, and defaults to false if not set. SaaS seller (ISV)
+		// schedules only.
+		CarryForwardEnabled *bool      `json:"carry_forward_enabled,omitempty"`
 		Recurrence          Recurrence `json:"recurrence,omitempty"`
 	}
 
@@ -131,6 +156,9 @@ func (p *PayoutSchedule) UnmarshalJSON(data []byte) error {
 
 			currency.Enabled = currencyMap[k].Enabled
 			currency.Threshold = currencyMap[k].Threshold
+			currency.PaymentInstrumentId = currencyMap[k].PaymentInstrumentId
+			currency.BalanceMinimum = currencyMap[k].BalanceMinimum
+			currency.CarryForwardEnabled = currencyMap[k].CarryForwardEnabled
 			p.Currency[k] = currency
 		}
 	}
@@ -146,9 +174,12 @@ func (p *PayoutSchedule) UnmarshalJSON(data []byte) error {
 
 type (
 	currencyUnmarshaler struct {
-		Enabled    bool `json:"enabled,omitempty"`
-		Threshold  int  `json:"threshold,omitempty"`
-		Recurrence struct {
+		Enabled             bool   `json:"enabled,omitempty"`
+		Threshold           int    `json:"threshold,omitempty"`
+		PaymentInstrumentId string `json:"payment_instrument_id,omitempty"`
+		BalanceMinimum      *int64 `json:"balance_minimum,omitempty"`
+		CarryForwardEnabled *bool  `json:"carry_forward_enabled,omitempty"`
+		Recurrence          struct {
 			Frequency
 		}
 	}

--- a/accounts/payouts_fields_test.go
+++ b/accounts/payouts_fields_test.go
@@ -1,0 +1,105 @@
+package accounts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies CurrencySchedule aligned with the 2026-08-05 Checkout.com swagger delta:
+// balance_minimum and carry_forward_enabled (SaaS seller ISV variant) plus
+// payment_instrument_id on both the update request and the retrieve response.
+
+func TestCurrencySchedule_MarshalNewFieldsPresentWhenSet(t *testing.T) {
+	balanceMinimum := int64(500)
+	carryForward := false
+
+	schedule := CurrencySchedule{
+		Enabled:             true,
+		Threshold:           100,
+		PaymentInstrumentId: "ppi_w4jelhppmfiufdnatam37wrfc4",
+		BalanceMinimum:      &balanceMinimum,
+		CarryForwardEnabled: &carryForward,
+		Recurrence:          NewScheduleFrequencyWeeklyRequest([]DaySchedule{Monday}),
+	}
+
+	marshalled, err := json.Marshal(schedule)
+	assert.NoError(t, err)
+	body := string(marshalled)
+	assert.Contains(t, body, `"payment_instrument_id":"ppi_w4jelhppmfiufdnatam37wrfc4"`)
+	assert.Contains(t, body, `"balance_minimum":500`)
+	assert.Contains(t, body, `"carry_forward_enabled":false`)
+}
+
+func TestCurrencySchedule_MarshalNewFieldsAbsentWhenUnset(t *testing.T) {
+	schedule := CurrencySchedule{
+		Enabled:    true,
+		Threshold:  100,
+		Recurrence: NewScheduleFrequencyDailyRequest(),
+	}
+
+	marshalled, err := json.Marshal(schedule)
+	assert.NoError(t, err)
+	body := string(marshalled)
+	assert.NotContains(t, body, "payment_instrument_id")
+	assert.NotContains(t, body, "balance_minimum")
+	assert.NotContains(t, body, "carry_forward_enabled")
+}
+
+func TestPayoutSchedule_UnmarshalNewFieldsPresent(t *testing.T) {
+	payload := `{
+		"GBP": {
+			"enabled": true,
+			"threshold": 100,
+			"balance_minimum": 500,
+			"carry_forward_enabled": true,
+			"payment_instrument_id": "ppi_w4jelhppmfiufdnatam37wrfc4",
+			"recurrence": {
+				"frequency": "weekly",
+				"by_day": ["monday"]
+			}
+		},
+		"_links": {
+			"self": {
+				"href": "https://api.checkout.com/accounts/entities/ent_wxglze3wwywujg4nna5fb7ldli"
+			}
+		}
+	}`
+
+	var schedule PayoutSchedule
+	assert.NoError(t, json.Unmarshal([]byte(payload), &schedule))
+
+	gbp := schedule.Currency["GBP"]
+	assert.True(t, gbp.Enabled)
+	assert.Equal(t, 100, gbp.Threshold)
+	assert.Equal(t, "ppi_w4jelhppmfiufdnatam37wrfc4", gbp.PaymentInstrumentId)
+	if assert.NotNil(t, gbp.BalanceMinimum) {
+		assert.Equal(t, int64(500), *gbp.BalanceMinimum)
+	}
+	if assert.NotNil(t, gbp.CarryForwardEnabled) {
+		assert.True(t, *gbp.CarryForwardEnabled)
+	}
+}
+
+func TestPayoutSchedule_UnmarshalNewFieldsAbsent(t *testing.T) {
+	payload := `{
+		"USD": {
+			"enabled": true,
+			"threshold": 100,
+			"recurrence": {
+				"frequency": "monthly",
+				"by_month_day": [1, 15]
+			}
+		},
+		"_links": {}
+	}`
+
+	var schedule PayoutSchedule
+	assert.NoError(t, json.Unmarshal([]byte(payload), &schedule))
+
+	usd := schedule.Currency["USD"]
+	assert.Empty(t, usd.PaymentInstrumentId)
+	assert.Nil(t, usd.BalanceMinimum)
+	assert.Nil(t, usd.CarryForwardEnabled)
+}

--- a/accounts/payouts_fields_test.go
+++ b/accounts/payouts_fields_test.go
@@ -103,3 +103,38 @@ func TestPayoutSchedule_UnmarshalNewFieldsAbsent(t *testing.T) {
 	assert.Nil(t, usd.BalanceMinimum)
 	assert.Nil(t, usd.CarryForwardEnabled)
 }
+
+// The OpenAPI spec (GetScheduleResponse / GetScheduleResponseIsv) describes a
+// different nesting: the currency object holds a "recurrence" wrapper that
+// contains enabled, threshold, balance_minimum, carry_forward_enabled and
+// payment_instrument_id, with the frequency under an inner "schedule" object.
+// Every typed SDK (this one, Java, .NET) models the flat shape asserted by the
+// tests above, and their integration suites pass against the live API, so the
+// flat shape is treated as the real contract and the spec wording as a spec
+// bug (reported). This test documents that a spec-shaped payload does NOT map:
+// if it ever starts mapping, the API moved and the models must follow.
+func TestPayoutSchedule_SpecShapedPayloadDoesNotMap(t *testing.T) {
+	payload := `{
+		"GBP": {
+			"recurrence": {
+				"enabled": true,
+				"threshold": 100,
+				"balance_minimum": 500,
+				"carry_forward_enabled": true,
+				"payment_instrument_id": "ppi_w4jelhppmfiufdnatam37wrfc4",
+				"schedule": {
+					"frequency": "weekly",
+					"by_day": ["monday"]
+				}
+			}
+		},
+		"_links": {}
+	}`
+
+	var schedule PayoutSchedule
+	err := json.Unmarshal([]byte(payload), &schedule)
+
+	// The spec-shaped recurrence object has no frequency at its top level, so
+	// the unmarshaler cannot dispatch and reports the currency as unsupported.
+	assert.Error(t, err)
+}

--- a/payments/nas/payments.go
+++ b/payments/nas/payments.go
@@ -110,8 +110,11 @@ type (
 	}
 
 	PaymentInstructionResponse struct {
-		ValueDate *time.Time             `json:"value_date,omitempty"`
-		Links     map[string]common.Link `json:"_links"`
+		ValueDate *time.Time `json:"value_date,omitempty"`
+		// FundsTransferType is the scheme's categorisation of the client,
+		// for example FD, MT or AA.
+		FundsTransferType string                 `json:"funds_transfer_type,omitempty"`
+		Links             map[string]common.Link `json:"_links"`
 	}
 
 	Identification struct {

--- a/payments/nas/payments_instruction_fields_test.go
+++ b/payments/nas/payments_instruction_fields_test.go
@@ -1,0 +1,31 @@
+package nas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies PaymentInstructionResponse aligned with the 2026-08-05 Checkout.com
+// swagger delta: funds_transfer_type on the card payout response instruction.
+
+func TestPaymentInstructionResponse_FundsTransferTypePresentWhenSet(t *testing.T) {
+	payload := `{"value_date":"2026-08-05T00:00:00Z","funds_transfer_type":"AA"}`
+
+	var instruction PaymentInstructionResponse
+	assert.NoError(t, json.Unmarshal([]byte(payload), &instruction))
+	assert.Equal(t, "AA", instruction.FundsTransferType)
+
+	marshalled, err := json.Marshal(instruction)
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshalled), `"funds_transfer_type":"AA"`)
+}
+
+func TestPaymentInstructionResponse_FundsTransferTypeAbsentWhenUnset(t *testing.T) {
+	instruction := PaymentInstructionResponse{}
+
+	marshalled, err := json.Marshal(instruction)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(marshalled), "funds_transfer_type")
+}


### PR DESCRIPTION
**Summary**
Adds the 2026-08-05 spec changes: the ISV (SaaS seller) payout schedule fields `balance_minimum` and `carry_forward_enabled`, plus `payment_instrument_id` which was present in the spec but missing from the SDK. Includes characterization tests pinning the payout schedule GET response shape and frequency serialization the API actually uses.

**Changes**
- Payout schedule request/response models: new optional `balance_minimum`, `carry_forward_enabled`, `payment_instrument_id`
- ISV constraints documented on the existing frequency types (working days only for weekly and daily; monthly accepts only [1], [15], [1,15] or [1,16]); no parallel Isv classes because the wire format is identical
- Serialization tests: fields present when set, absent when unset; spec-shape characterization tests

**API Reference**
- `GET /accounts/entities/{id}/payout-schedules`
- `PUT /accounts/entities/{id}/payout-schedules`

**Breaking changes**
None.

**README**
No README impact.