### PR TITLE
Release 3.0.0

### DIFF
--- a/client/version.go
+++ b/client/version.go
@@ -1,3 +1,3 @@
 package client
 
-const SDK_VERSION = "2.9.2"
+const SDK_VERSION = "3.0.0"


### PR DESCRIPTION
- Consumers must update their imports from `github.com/checkout/checkout-sdk-go/v2` to `/v3` (#245)
- The merchant-specific subdomain (WithEnvironmentSubdomain) is now required. Set it, or call the deprecated WithLegacyDomain() to keep using the shared checkout.com hosts (#235)
- An invalid subdomain now returns an error instead of being silently ignored (#235)
- Setting a subdomain no longer disables telemetry (#235)
- Add optional amount to VoidRequest to support partial voids (#243)
- Add the ISV (SaaS seller) payout schedule fields BalanceMinimum, CarryForwardEnabled and PaymentInstrumentId (#244)