### PR TITLE
docs: correct the version labels left over from the v3 rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 
 ## Getting started
 
-> **Version 2.0.0 is here!**
+> **Version 3.0.0 is here!**
 > <br/><br/>
-> We added comprehensive `context.Context` support across all SDK clients. <br/>
-> All client methods now have `*WithContext` variants for better timeout handling, cancellation support, and request lifecycle control. <br/>
-> Backward compatibility is maintained: existing methods continue to work by using `context.Background()` internally. <br/>
+> The module path is now `github.com/checkout/checkout-sdk-go/v3`, so update your imports when you upgrade. <br/>
+> Your merchant-specific subdomain is now required: call `WithEnvironmentSubdomain()`, or the deprecated `WithLegacyDomain()` to keep using the shared hosts. <br/>
+> `context.Context` support from 2.0.0 is unchanged: every client method still has a `*WithContext` variant, and the plain methods keep working. <br/>
 
 ### Module installer
 Make sure your project is using Go Modules:
 ```sh
-# For v2.x (current)
+# For v3.x (current)
 go get github.com/checkout/checkout-sdk-go/v3
 
 # For v1.x (legacy)
@@ -28,7 +28,7 @@ go get github.com/checkout/checkout-sdk-go@v1.9.0
 ```
 Then import the library into your code:
 ```sh
-# For v2.x
+# For v3.x
 import "github.com/checkout/checkout-sdk-go/v3"
 
 # For v1.x


### PR DESCRIPTION
**Summary**
The `/v3` rename updated the install and import snippets but not the prose around them, so the README announced "Version 2.0.0 is here!" and labelled both `/v3` snippets as `v2.x (current)`. Anyone landing on the page while upgrading reads a contradiction.

**Changes**
- `README.md` — banner now describes 3.0.0 (new module path, mandatory merchant-specific subdomain, and that the 2.0.0 `context.Context` support is unchanged); the two snippet labels now read `v3.x`

**API Reference**
Not applicable, documentation only.

**Breaking changes**
None.

**README**
This PR is the README update.