### PR TITLE
feature/INT-1675 - BACS Direct Debit notifications + refactor - #232

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 
 .idea
 *.DS_Store*
-.cursor/rules/*.mdc
-.cursor/skills/endpoint-review-auto/*.md
+.cursor/
 .claude/
 CLAUDE.md

--- a/apm/bacs/bacs.go
+++ b/apm/bacs/bacs.go
@@ -1,0 +1,46 @@
+package bacs
+
+import "github.com/checkout/checkout-sdk-go/v3/common"
+
+const (
+	apmsPath          = "apms"
+	bacsPath          = "bacs"
+	notificationsPath = "notifications"
+)
+
+// NotificationType is the type of pre-notification being sent to the payer.
+type NotificationType string
+
+const (
+	AdvanceNotice NotificationType = "advance_notice"
+)
+
+type (
+	// NotificationRequest is a Bacs Direct Debit pre-notification request.
+	//
+	// SourceId matches the pattern ^(src)_(\w{26})$. CollectionDate is a yyyy-MM-dd date. Amount is
+	// in the currency's minor unit with a minimum of 1. Currency is min 3 max 3 characters. Reference
+	// is max 50 and BillingDescriptor max 25 characters. CustomerEmail and SupportEmail are email
+	// addresses, and SupportPhone is in E.164 format. Reference and SupportPhone are the only
+	// optional properties, and are the only two tagged omitempty: the eight required fields always
+	// serialize, so a forgotten one surfaces as an explicit zero value rather than a silently
+	// absent key.
+	NotificationRequest struct {
+		SourceId          string               `json:"source_id" binding:"required"`
+		NotificationType  NotificationType     `json:"notification_type" binding:"required"`
+		CollectionDate    *common.APIShortDate `json:"collection_date" binding:"required"`
+		Amount            int64                `json:"amount" binding:"required"`
+		Currency          common.Currency      `json:"currency" binding:"required"`
+		CustomerEmail     string               `json:"customer_email" binding:"required"`
+		BillingDescriptor string               `json:"billing_descriptor" binding:"required"`
+		SupportEmail      string               `json:"support_email" binding:"required"`
+		Reference         string               `json:"reference,omitempty"`
+		SupportPhone      string               `json:"support_phone,omitempty"`
+	}
+
+	// NotificationResponse is the Bacs Direct Debit pre-notification response.
+	NotificationResponse struct {
+		HttpMetadata common.HttpMetadata `json:"http_metadata,omitempty"`
+		EventId      string              `json:"event_id,omitempty"`
+	}
+)

--- a/apm/bacs/bacs_serialization_test.go
+++ b/apm/bacs/bacs_serialization_test.go
@@ -1,0 +1,89 @@
+package bacs
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/common"
+)
+
+// Schema validation tests for NotificationRequest against the swagger schema of
+// POST /apms/bacs/notifications. Covers all 10 properties.
+
+func TestNotificationRequestSerializesEveryProperty(t *testing.T) {
+	collectionDate := common.APIShortDate(time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
+
+	raw, err := json.Marshal(NotificationRequest{
+		SourceId:          "src_wmlfc3zyhqzehihu7giusaaawu",
+		NotificationType:  AdvanceNotice,
+		CollectionDate:    &collectionDate,
+		Amount:            4999,
+		Currency:          common.GBP,
+		Reference:         "INV-12345",
+		CustomerEmail:     "customer@example.com",
+		BillingDescriptor: "CHECKOUT",
+		SupportEmail:      "support@test.com",
+		SupportPhone:      "+447700900123",
+	})
+	assert.Nil(t, err)
+
+	var body map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &body))
+
+	assert.Equal(t, "src_wmlfc3zyhqzehihu7giusaaawu", body["source_id"])
+	assert.Equal(t, "advance_notice", body["notification_type"])
+	assert.Equal(t, "2026-07-15", body["collection_date"])
+	assert.Equal(t, float64(4999), body["amount"])
+	assert.Equal(t, "GBP", body["currency"])
+	assert.Equal(t, "INV-12345", body["reference"])
+	assert.Equal(t, "customer@example.com", body["customer_email"])
+	assert.Equal(t, "CHECKOUT", body["billing_descriptor"])
+	assert.Equal(t, "support@test.com", body["support_email"])
+	assert.Equal(t, "+447700900123", body["support_phone"])
+	assert.Len(t, body, 10)
+}
+
+// The eight required fields carry binding:"required" and no omitempty, matching the SDK convention,
+// so a forgotten one serializes as an explicit zero rather than a silently absent key. The two
+// optional fields are the only ones omitted when unset.
+func TestNotificationRequestAlwaysSerializesTheRequiredFields(t *testing.T) {
+	raw, err := json.Marshal(NotificationRequest{})
+	assert.Nil(t, err)
+
+	var body map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &body))
+
+	for _, key := range []string{
+		"source_id", "notification_type", "collection_date", "amount",
+		"currency", "customer_email", "billing_descriptor", "support_email",
+	} {
+		_, present := body[key]
+		assert.True(t, present, "required field %s must always serialize", key)
+	}
+
+	_, hasReference := body["reference"]
+	_, hasSupportPhone := body["support_phone"]
+	assert.False(t, hasReference)
+	assert.False(t, hasSupportPhone)
+	assert.Len(t, body, 8)
+}
+
+func TestCollectionDateSerializesAsAShortDate(t *testing.T) {
+	// The specification declares collection_date as format: date. common.APIShortDate marshals
+	// yyyy-MM-dd; a plain time.Time would emit a full RFC 3339 timestamp.
+	collectionDate := common.APIShortDate(time.Date(2026, 7, 15, 13, 45, 0, 0, time.UTC))
+
+	raw, err := json.Marshal(NotificationRequest{CollectionDate: &collectionDate})
+	assert.Nil(t, err)
+
+	var body map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &body))
+	assert.Equal(t, "2026-07-15", body["collection_date"])
+}
+
+func TestNotificationTypeCarriesTheSingleDeclaredValue(t *testing.T) {
+	assert.Equal(t, "advance_notice", string(AdvanceNotice))
+}

--- a/apm/bacs/client.go
+++ b/apm/bacs/client.go
@@ -1,0 +1,52 @@
+package bacs
+
+import (
+	"context"
+
+	"github.com/checkout/checkout-sdk-go/v3/client"
+	"github.com/checkout/checkout-sdk-go/v3/common"
+	"github.com/checkout/checkout-sdk-go/v3/configuration"
+)
+
+type Client struct {
+	configuration *configuration.Configuration
+	apiClient     client.HttpClient
+}
+
+func NewClient(configuration *configuration.Configuration, apiClient client.HttpClient) *Client {
+	return &Client{
+		configuration: configuration,
+		apiClient:     apiClient,
+	}
+}
+
+// SendNotification sends a Bacs Direct Debit pre-notification (advance notice) to a payer ahead of
+// collecting funds from their account. Calls POST /apms/bacs/notifications.
+func (c *Client) SendNotification(request NotificationRequest) (*NotificationResponse, error) {
+	return c.SendNotificationWithContext(context.Background(), request)
+}
+
+func (c *Client) SendNotificationWithContext(
+	ctx context.Context,
+	request NotificationRequest,
+) (*NotificationResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var response NotificationResponse
+	err = c.apiClient.PostWithContext(
+		ctx,
+		common.BuildPath(apmsPath, bacsPath, notificationsPath),
+		auth,
+		request,
+		&response,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/apm/bacs/client_test.go
+++ b/apm/bacs/client_test.go
@@ -1,0 +1,96 @@
+package bacs
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/checkout/checkout-sdk-go/v3/configuration"
+	"github.com/checkout/checkout-sdk-go/v3/errors"
+	"github.com/checkout/checkout-sdk-go/v3/mocks"
+)
+
+func TestSendNotification(t *testing.T) {
+	var (
+		notification = NotificationResponse{
+			HttpMetadata: mocks.HttpMetadataStatusCreated,
+			EventId:      "evt_lzr4csdtddwetactr6phd3kea4",
+		}
+	)
+
+	cases := []struct {
+		name             string
+		request          NotificationRequest
+		getAuthorization func(*mock.Mock) mock.Call
+		apiPost          func(*mock.Mock) mock.Call
+		checker          func(*NotificationResponse, error)
+	}{
+		{
+			name:    "when request is valid then send the pre-notification",
+			request: NotificationRequest{SourceId: "src_wmlfc3zyhqzehihu7giusaaawu"},
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil).
+					Run(func(args mock.Arguments) {
+						// Positional args are (ctx, path, auth, request, response, idempotencyKey).
+						assert.Equal(t, "/apms/bacs/notifications", args.Get(1))
+						respMapping := args.Get(4).(*NotificationResponse)
+						*respMapping = notification
+					})
+			},
+			checker: func(response *NotificationResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusCreated, response.HttpMetadata.StatusCode)
+				assert.Equal(t, notification.EventId, response.EventId)
+			},
+		},
+		{
+			name:    "when request is invalid then return error",
+			request: NotificationRequest{},
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiPost: func(m *mock.Mock) mock.Call {
+				return *m.On("PostWithContext",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(
+						errors.CheckoutAPIError{
+							StatusCode: http.StatusUnprocessableEntity,
+							Status:     "422 Invalid data was sent",
+						})
+			},
+			checker: func(response *NotificationResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusUnprocessableEntity, chkErr.StatusCode)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiClient := new(mocks.ApiClientMock)
+			credentials := new(mocks.CredentialsMock)
+			environment := new(mocks.EnvironmentMock)
+			enableTelemetry := true
+
+			tc.getAuthorization(&credentials.Mock)
+			tc.apiPost(&apiClient.Mock)
+
+			config := configuration.NewConfiguration(credentials, &enableTelemetry, environment, &http.Client{}, nil)
+			client := NewClient(config, apiClient)
+
+			tc.checker(client.SendNotification(tc.request))
+		})
+	}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -308,8 +308,10 @@ const (
 	BankAccount InstrumentType = "bank_account"
 	Token       InstrumentType = "token"
 	Sepa        InstrumentType = "sepa"
-	CardToken   InstrumentType = "card_token"
 	Ach         InstrumentType = "ach"
+	Bacs        InstrumentType = "bacs"
+	// CardToken is Previous API (ABC) only. The current API's instrument type does not declare it.
+	CardToken InstrumentType = "card_token"
 )
 
 type (

--- a/instruments/nas/bacs_serialization_test.go
+++ b/instruments/nas/bacs_serialization_test.go
@@ -2,7 +2,7 @@ package nas
 
 import (
 	"encoding/json"
-	"os"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -264,7 +264,7 @@ func TestRetrieveResponseUsesAGetSpecificAccountHolder(t *testing.T) {
 // Every exported Bacs response type carries GoDoc, per the Go SDK conventions.
 func TestBacsResponseTypesAreDocumented(t *testing.T) {
 	for _, file := range []string{"create.go", "get.go", "update.go"} {
-		src, err := os.ReadFile(file)
+		src, err := ioutil.ReadFile(file)
 		assert.Nil(t, err)
 		text := string(src)
 		for _, name := range []string{
@@ -284,7 +284,7 @@ func TestBacsResponseTypesAreDocumented(t *testing.T) {
 // The validations slice is untyped because the specification publishes no item schema. The comment
 // recording that must survive, so the next reader does not assume it was an oversight.
 func TestValidationsIsDocumentedAsUntyped(t *testing.T) {
-	src, err := os.ReadFile("get.go")
+	src, err := ioutil.ReadFile("get.go")
 	assert.Nil(t, err)
 	assert.Contains(t, string(src), "no item schema")
 }

--- a/instruments/nas/bacs_serialization_test.go
+++ b/instruments/nas/bacs_serialization_test.go
@@ -1,0 +1,290 @@
+package nas
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/common"
+	"github.com/checkout/checkout-sdk-go/v3/payments"
+)
+
+// Schema validation tests for the Bacs Direct Debit, SEPA and ACH instrument families against
+// StoreBacsInstrumentRequest, UpdateBacsInstrumentRequest, StoreSepaInstrumentRequest,
+// StoreAchInstrumentRequest and RetrieveBacsInstrumentResponse.
+
+func decode(t *testing.T, v interface{}) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	assert.Nil(t, err)
+	var out map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+func TestBacsStoreRequestSerializesEveryProperty(t *testing.T) {
+	allowPartial := false
+	r := NewCreateBacsInstrumentRequest()
+	r.Account = &BacsInstrumentAccount{ProcessingChannelId: "pc_q4dbxom5jbgudnjzjpz7j2z6uq"}
+	r.InstrumentData = &BacsInstrumentData{
+		AccountNumber:     "86753246",
+		BankCode:          "040004",
+		Country:           common.GB,
+		Currency:          common.GBP,
+		PaymentType:       BacsRecurring,
+		AllowPartialMatch: &allowPartial,
+	}
+	r.AccountHolder = &CreateBacsAccountHolder{
+		FirstName: "John",
+		LastName:  "Smith",
+		BillingAddress: &BacsBillingAddress{
+			AddressLine1: "Cloverfield St.",
+			AddressLine2: "23A",
+			City:         "London",
+			Zip:          "SW1A 1AA",
+			Country:      common.GB,
+		},
+	}
+
+	body := decode(t, r)
+
+	assert.Equal(t, "bacs", body["type"])
+	assert.Equal(t, "pc_q4dbxom5jbgudnjzjpz7j2z6uq",
+		body["account"].(map[string]interface{})["processing_channel_id"])
+
+	data := body["instrument_data"].(map[string]interface{})
+	assert.Equal(t, "86753246", data["account_number"])
+	assert.Equal(t, "040004", data["bank_code"])
+	assert.Equal(t, "GB", data["country"])
+	assert.Equal(t, "GBP", data["currency"])
+	assert.Equal(t, "Recurring", data["payment_type"])
+	assert.Equal(t, false, data["allow_partial_match"])
+
+	holder := body["account_holder"].(map[string]interface{})
+	assert.Equal(t, "John", holder["first_name"])
+	assert.Equal(t, "Smith", holder["last_name"])
+	address := holder["billing_address"].(map[string]interface{})
+	assert.Equal(t, "Cloverfield St.", address["address_line1"])
+	assert.Equal(t, "23A", address["address_line2"])
+	assert.Equal(t, "London", address["city"])
+	assert.Equal(t, "SW1A 1AA", address["zip"])
+	assert.Equal(t, "GB", address["country"])
+
+	// StoreBacsInstrumentRequest.account_holder declares no company_name or type.
+	_, hasCompany := holder["company_name"]
+	_, hasType := holder["type"]
+	assert.False(t, hasCompany)
+	assert.False(t, hasType)
+}
+
+func TestBacsUpdateRequestSerializesTheFivePropertyAccountHolder(t *testing.T) {
+	allowPartial := true
+	r := NewUpdateBacsInstrumentRequest()
+	r.InstrumentData = &BacsInstrumentData{
+		PaymentType:       BacsRegular,
+		AllowPartialMatch: &allowPartial,
+	}
+	r.AccountHolder = &UpdateBacsAccountHolder{
+		FirstName:   "John",
+		LastName:    "Smith",
+		CompanyName: "Wayne Enterprises",
+		Type:        InstrumentAccountHolderCorporate,
+	}
+
+	body := decode(t, r)
+
+	assert.Equal(t, "bacs", body["type"])
+	data := body["instrument_data"].(map[string]interface{})
+	assert.Equal(t, "Regular", data["payment_type"])
+	assert.Equal(t, true, data["allow_partial_match"])
+	holder := body["account_holder"].(map[string]interface{})
+	assert.Equal(t, "Wayne Enterprises", holder["company_name"])
+	assert.Equal(t, "corporate", holder["type"])
+}
+
+func TestSepaPaymentTypeStaysLowercaseAndBacsStaysCapitalized(t *testing.T) {
+	// The specification declares the SEPA payment_type lowercase and the Bacs Direct Debit
+	// payment_type capitalized. This is the regression test that stops the two being unified.
+	assert.Equal(t, "recurring", string(SepaRecurring))
+	assert.Equal(t, "regular", string(SepaRegular))
+	assert.Equal(t, "Recurring", string(BacsRecurring))
+	assert.Equal(t, "Regular", string(BacsRegular))
+
+	// payments.PaymentType serializes capitalized values and carries values neither instrument
+	// schema allows, so it must not be used for either field.
+	assert.NotEqual(t, string(SepaRecurring), string(payments.Recurring))
+}
+
+func TestSepaStoreRequestCarriesTheMandateType(t *testing.T) {
+	r := NewCreateSepaInstrumentRequest()
+	r.InstrumentData = &InstrumentData{
+		Type:          SepaMandateB2B,
+		AccountNumber: "FR2810096000509685512959O86",
+		Country:       common.FR,
+		Currency:      common.EUR,
+		PaymentType:   SepaRecurring,
+		MandateId:     "1234567890",
+	}
+	r.AccountHolder = &SepaAccountHolder{
+		FirstName:   "John",
+		LastName:    "Wick",
+		CompanyName: "Checkout.com",
+		Type:        InstrumentAccountHolderIndividual,
+	}
+
+	body := decode(t, r)
+	data := body["instrument_data"].(map[string]interface{})
+
+	assert.Equal(t, "sepa", body["type"])
+	assert.Equal(t, "B2B", data["type"])
+	assert.Equal(t, "recurring", data["payment_type"])
+	assert.Equal(t, "individual", body["account_holder"].(map[string]interface{})["type"])
+}
+
+func TestAchAccountTypeIsNotTheBankAccountSet(t *testing.T) {
+	// The ACH field declares savings and checking; common.AccountType declares savings, current
+	// and cash.
+	assert.Equal(t, "savings", string(AchSavings))
+	assert.Equal(t, "checking", string(AchChecking))
+	assert.Equal(t, "current", string(common.Current))
+}
+
+func TestAchAccountHolderDeclaresNoBillingAddress(t *testing.T) {
+	r := NewCreateAchInstrumentRequest()
+	r.InstrumentData = &AchInstrumentData{
+		AccountType:   AchChecking,
+		AccountNumber: "4099999992",
+		BankCode:      "211370545",
+		Currency:      common.USD,
+		Country:       common.US,
+	}
+	r.AccountHolder = &AchAccountHolder{
+		FirstName:   "John",
+		LastName:    "Smith",
+		CompanyName: "Smith Enterprises",
+		Type:        InstrumentAccountHolderCorporate,
+	}
+
+	body := decode(t, r)
+	holder := body["account_holder"].(map[string]interface{})
+
+	assert.Equal(t, "checking", body["instrument_data"].(map[string]interface{})["account_type"])
+	assert.Len(t, holder, 4)
+	_, hasAddress := holder["billing_address"]
+	assert.False(t, hasAddress)
+}
+
+func TestInstrumentResponseDispatchResolvesBacs(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want func(t *testing.T)
+	}{}
+	_ = cases
+
+	createBody := `{"type":"bacs","id":"src_wmlfc3zyhqzehihu7giusaaawu","fingerprint":"vnsdrvikkvre3dtrjjvlm5du4q"}`
+
+	var create CreateInstrumentResponse
+	assert.Nil(t, json.Unmarshal([]byte(createBody), &create))
+	assert.NotNil(t, create.CreateBacsInstrumentResponse)
+	assert.Equal(t, common.Bacs, create.CreateBacsInstrumentResponse.Type)
+	assert.Equal(t, "src_wmlfc3zyhqzehihu7giusaaawu", create.CreateBacsInstrumentResponse.Id)
+
+	var update UpdateInstrumentResponse
+	assert.Nil(t, json.Unmarshal([]byte(createBody), &update))
+	assert.NotNil(t, update.UpdateBacsInstrumentResponse)
+	assert.Equal(t, common.Bacs, update.UpdateBacsInstrumentResponse.Type)
+
+	getBody := `{
+		"type":"bacs",
+		"id":"src_wmlfc3zyhqzehihu7giusaaawu",
+		"fingerprint":"vnsdrvikkvre3dtrjjvlm5du4q",
+		"created_on":"2021-01-01T00:00:00Z",
+		"modified_on":"2021-02-02T10:30:00Z",
+		"vault_id":"vid_wmlfc3zyhqzehihu7giusaaawu",
+		"account":{"client_id":"cli_x","processing_channel_id":"pc_x"},
+		"validations":[{"type":"name_match"}],
+		"instrument_data":{
+			"account_number":"86753246","bank_code":"040004","country":"GB","currency":"GBP",
+			"payment_type":"Recurring","allow_partial_match":true,
+			"status":"INVALID","match_status":"no match","description":"The name did not match.",
+			"mandate_id":"6PZ6KFI3KW3UFHAM3J"
+		},
+		"account_holder":{"first_name":"Hannah","last_name":"Bret","type":"corporate"}
+	}`
+
+	var get GetInstrumentResponse
+	assert.Nil(t, json.Unmarshal([]byte(getBody), &get))
+	assert.NotNil(t, get.GetBacsInstrumentResponse)
+	r := get.GetBacsInstrumentResponse
+	assert.Equal(t, common.Bacs, r.Type)
+	assert.Equal(t, "vid_wmlfc3zyhqzehihu7giusaaawu", r.VaultId)
+	assert.Equal(t, "pc_x", r.Account.ProcessingChannelId)
+	assert.Len(t, r.Validations, 1)
+	assert.Equal(t, BacsRecurring, r.InstrumentData.PaymentType)
+	assert.Equal(t, "INVALID", r.InstrumentData.Status)
+	assert.Equal(t, "no match", r.InstrumentData.MatchStatus)
+	assert.Equal(t, "6PZ6KFI3KW3UFHAM3J", r.InstrumentData.MandateId)
+	assert.Equal(t, InstrumentAccountHolderCorporate, r.AccountHolder.Type)
+}
+
+func TestInstrumentTypeCarriesBacs(t *testing.T) {
+	assert.Equal(t, "bacs", string(common.Bacs))
+	assert.Equal(t, "ach", string(common.Ach))
+	assert.Equal(t, common.Bacs, NewCreateBacsInstrumentRequest().Type)
+	assert.Equal(t, common.Bacs, NewUpdateBacsInstrumentRequest().Type)
+}
+
+// The retrieve response uses a Get-specific account holder rather than the request-named
+// UpdateBacsAccountHolder. The two are structurally identical, which is why the reuse compiled.
+func TestRetrieveResponseUsesAGetSpecificAccountHolder(t *testing.T) {
+	field, found := reflect.TypeOf(GetBacsInstrumentResponse{}).FieldByName("AccountHolder")
+	assert.True(t, found)
+	assert.Equal(t, "*nas.GetBacsAccountHolder", field.Type.String())
+
+	// Same five properties as the update shape, per the specification.
+	got := map[string]bool{}
+	ht := reflect.TypeOf(GetBacsAccountHolder{})
+	for i := 0; i < ht.NumField(); i++ {
+		got[ht.Field(i).Tag.Get("json")] = true
+	}
+	for _, tag := range []string{
+		"first_name,omitempty", "last_name,omitempty", "company_name,omitempty",
+		"billing_address,omitempty", "type,omitempty",
+	} {
+		assert.True(t, got[tag], "expected json tag %s", tag)
+	}
+	assert.Len(t, got, 5)
+}
+
+// Every exported Bacs response type carries GoDoc, per the Go SDK conventions.
+func TestBacsResponseTypesAreDocumented(t *testing.T) {
+	for _, file := range []string{"create.go", "get.go", "update.go"} {
+		src, err := os.ReadFile(file)
+		assert.Nil(t, err)
+		text := string(src)
+		for _, name := range []string{
+			"CreateBacsInstrumentResponse", "GetBacsInstrumentResponse", "UpdateBacsInstrumentResponse",
+		} {
+			idx := strings.Index(text, "\t"+name+" struct {")
+			if idx < 0 {
+				continue
+			}
+			preceding := text[:idx]
+			lastLine := preceding[strings.LastIndex(preceding[:len(preceding)-1], "\n")+1:]
+			assert.Contains(t, lastLine, "//", "%s in %s needs GoDoc", name, file)
+		}
+	}
+}
+
+// The validations slice is untyped because the specification publishes no item schema. The comment
+// recording that must survive, so the next reader does not assume it was an oversight.
+func TestValidationsIsDocumentedAsUntyped(t *testing.T) {
+	src, err := os.ReadFile("get.go")
+	assert.Nil(t, err)
+	assert.Contains(t, string(src), "no item schema")
+}

--- a/instruments/nas/client_test.go
+++ b/instruments/nas/client_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/checkout/checkout-sdk-go/v3/configuration"
 	"github.com/checkout/checkout-sdk-go/v3/errors"
 	"github.com/checkout/checkout-sdk-go/v3/mocks"
-	"github.com/checkout/checkout-sdk-go/v3/payments"
 )
 
 const (
@@ -246,7 +245,7 @@ func getCreateSepaInstrumentRequest() *createSepaInstrumentRequest {
 		AccountNumber:   "FR2810096000509685512959O86",
 		Country:         common.GB,
 		Currency:        common.GBP,
-		PaymentType:     payments.Recurring,
+		PaymentType:     SepaRecurring,
 		MandateId:       "1234567890",
 		DateOfSignature: apiDate,
 	}

--- a/instruments/nas/create.go
+++ b/instruments/nas/create.go
@@ -48,14 +48,22 @@ type (
 	createSepaInstrumentRequest struct {
 		Type           common.InstrumentType            `json:"type" binding:"required"`
 		InstrumentData *InstrumentData                  `json:"instrument_data,omitempty"`
-		AccountHolder  *common.AccountHolder            `json:"account_holder" binding:"required"`
+		AccountHolder  *SepaAccountHolder               `json:"account_holder" binding:"required"`
 		Customer       *CreateCustomerInstrumentRequest `json:"customer,omitempty"`
 	}
 
 	createAchInstrumentRequest struct {
 		Type           common.InstrumentType            `json:"type" binding:"required"`
 		InstrumentData *AchInstrumentData               `json:"instrument_data,omitempty"`
-		AccountHolder  *common.AccountHolder            `json:"account_holder" binding:"required"`
+		AccountHolder  *AchAccountHolder                `json:"account_holder" binding:"required"`
+		Customer       *CreateCustomerInstrumentRequest `json:"customer,omitempty"`
+	}
+
+	createBacsInstrumentRequest struct {
+		Type           common.InstrumentType            `json:"type" binding:"required"`
+		Account        *BacsInstrumentAccount           `json:"account" binding:"required"`
+		InstrumentData *BacsInstrumentData              `json:"instrument_data" binding:"required"`
+		AccountHolder  *CreateBacsAccountHolder         `json:"account_holder" binding:"required"`
 		Customer       *CreateCustomerInstrumentRequest `json:"customer,omitempty"`
 	}
 )
@@ -90,6 +98,12 @@ func NewCreateAchInstrumentRequest() *createAchInstrumentRequest {
 	}
 }
 
+func NewCreateBacsInstrumentRequest() *createBacsInstrumentRequest {
+	return &createBacsInstrumentRequest{
+		Type: common.Bacs,
+	}
+}
+
 type (
 	CreateInstrumentResponse struct {
 		HttpMetadata                        common.HttpMetadata
@@ -98,6 +112,7 @@ type (
 		CreateTokenInstrumentResponse       *CreateTokenInstrumentResponse
 		CreateSepaInstrumentResponse        *CreateSepaInstrumentResponse
 		CreateAchInstrumentResponse         *CreateAchInstrumentResponse
+		CreateBacsInstrumentResponse        *CreateBacsInstrumentResponse
 		AlternativeResponse                 *common.AlternativeResponse
 	}
 
@@ -168,6 +183,14 @@ type (
 		Id          string                `json:"id,omitempty"`
 		Fingerprint string                `json:"fingerprint,omitempty"`
 	}
+
+	// CreateBacsInstrumentResponse is the response returned after storing a Bacs Direct Debit
+	// instrument. StoreBacsInstrumentResponse declares type, id and fingerprint.
+	CreateBacsInstrumentResponse struct {
+		Type        common.InstrumentType `json:"type" binding:"required"`
+		Id          string                `json:"id,omitempty"`
+		Fingerprint string                `json:"fingerprint,omitempty"`
+	}
 )
 
 func (s *CreateInstrumentResponse) UnmarshalJSON(data []byte) error {
@@ -207,6 +230,12 @@ func (s *CreateInstrumentResponse) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 		s.CreateAchInstrumentResponse = &response
+	case string(common.Bacs):
+		var response CreateBacsInstrumentResponse
+		if err := json.Unmarshal(data, &response); err != nil {
+			return nil
+		}
+		s.CreateBacsInstrumentResponse = &response
 	default:
 		var response common.AlternativeResponse
 		if err := json.Unmarshal(data, &response); err != nil {

--- a/instruments/nas/get.go
+++ b/instruments/nas/get.go
@@ -20,6 +20,7 @@ type (
 		GetSepaInstrumentResponse        *GetSepaInstrumentResponse
 		GetBankAccountInstrumentResponse *GetBankAccountInstrumentResponse
 		GetAchInstrumentResponse         *GetAchInstrumentResponse
+		GetBacsInstrumentResponse        *GetBacsInstrumentResponse
 		AlternativeResponse              *common.AlternativeResponse
 	}
 
@@ -84,7 +85,60 @@ type (
 		ModifiedOn     *time.Time                              `json:"modified_on,omitempty"`
 		VaultId        string                                  `json:"vault_id,omitempty"`
 		InstrumentData *AchInstrumentData                      `json:"instrument_data,omitempty"`
-		AccountHolder  *common.AccountHolder                   `json:"account_holder,omitempty"`
+		AccountHolder  *AchAccountHolder                       `json:"account_holder,omitempty"`
+		Customer       *instruments.InstrumentCustomerResponse `json:"customer,omitempty"`
+	}
+
+	// GetBacsAccountHolder is the account holder details of a stored Bacs Direct Debit instrument.
+	//
+	// Structurally identical to UpdateBacsAccountHolder, but kept separate so a response field is not
+	// typed with a request-named type. RetrieveBacsInstrumentResponse requires FirstName, LastName and
+	// BillingAddress.
+	GetBacsAccountHolder struct {
+		FirstName      string                      `json:"first_name,omitempty"`
+		LastName       string                      `json:"last_name,omitempty"`
+		CompanyName    string                      `json:"company_name,omitempty"`
+		BillingAddress *BacsBillingAddress         `json:"billing_address,omitempty"`
+		Type           InstrumentAccountHolderType `json:"type,omitempty"`
+	}
+
+	// GetBacsInstrumentAccount is the account configuration returned on a stored Bacs instrument.
+	GetBacsInstrumentAccount struct {
+		ClientId            string `json:"client_id,omitempty"`
+		ProcessingChannelId string `json:"processing_channel_id,omitempty"`
+	}
+
+	// GetBacsInstrumentData is the details of a stored Bacs Direct Debit account.
+	//
+	// Status, MatchStatus, Description and MandateId are read-back fields the store and update
+	// shapes do not declare. Status and MatchStatus are free-form strings in the specification.
+	GetBacsInstrumentData struct {
+		AccountNumber     string          `json:"account_number,omitempty"`
+		BankCode          string          `json:"bank_code,omitempty"`
+		Country           common.Country  `json:"country,omitempty"`
+		Currency          common.Currency `json:"currency,omitempty"`
+		PaymentType       BacsPaymentType `json:"payment_type,omitempty"`
+		AllowPartialMatch *bool           `json:"allow_partial_match,omitempty"`
+		Status            string          `json:"status,omitempty"`
+		MatchStatus       string          `json:"match_status,omitempty"`
+		Description       string          `json:"description,omitempty"`
+		MandateId         string          `json:"mandate_id,omitempty"`
+	}
+
+	// GetBacsInstrumentResponse is the details of a stored Bacs Direct Debit instrument.
+	GetBacsInstrumentResponse struct {
+		Type        common.InstrumentType     `json:"type" binding:"required"`
+		Id          string                    `json:"id,omitempty"`
+		Fingerprint string                    `json:"fingerprint,omitempty"`
+		CreatedOn   *time.Time                `json:"created_on,omitempty"`
+		ModifiedOn  *time.Time                `json:"modified_on,omitempty"`
+		VaultId     string                    `json:"vault_id,omitempty"`
+		Account     *GetBacsInstrumentAccount `json:"account,omitempty"`
+		// Validations is untyped because the specification declares the array items as a bare
+		// object with no item schema. Retype it once the item schema is published.
+		Validations    []map[string]interface{}                `json:"validations,omitempty"`
+		InstrumentData *GetBacsInstrumentData                  `json:"instrument_data,omitempty"`
+		AccountHolder  *GetBacsAccountHolder                   `json:"account_holder,omitempty"`
 		Customer       *instruments.InstrumentCustomerResponse `json:"customer,omitempty"`
 	}
 
@@ -154,6 +208,12 @@ func (s *GetInstrumentResponse) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 		s.GetAchInstrumentResponse = &response
+	case string(common.Bacs):
+		var response GetBacsInstrumentResponse
+		if err := json.Unmarshal(data, &response); err != nil {
+			return nil
+		}
+		s.GetBacsInstrumentResponse = &response
 	default:
 		var response common.AlternativeResponse
 		if err := json.Unmarshal(data, &response); err != nil {

--- a/instruments/nas/instuments.go
+++ b/instruments/nas/instuments.go
@@ -2,7 +2,6 @@ package nas
 
 import (
 	"github.com/checkout/checkout-sdk-go/v3/common"
-	"github.com/checkout/checkout-sdk-go/v3/payments"
 )
 
 type PaymentNetwork string
@@ -16,21 +15,170 @@ const (
 	Swift   PaymentNetwork = "swift"
 )
 
+// SepaPaymentType is the type of payment for a SEPA instrument.
+//
+// The wire values are lowercase. The equivalent Bacs Direct Debit field is capitalized, so do not
+// share one type between the two. Do not use payments.PaymentType either: it serializes capitalized
+// values and also carries MOTO, Installment, PayLater and Unscheduled, which SEPA does not allow.
+type SepaPaymentType string
+
+const (
+	SepaRecurring SepaPaymentType = "recurring"
+	SepaRegular   SepaPaymentType = "regular"
+)
+
+// BacsPaymentType is the type of payment for a Bacs Direct Debit instrument.
+//
+// The wire values are capitalized. The equivalent SEPA field is lowercase, so do not share one type
+// between the two.
+type BacsPaymentType string
+
+const (
+	BacsRecurring BacsPaymentType = "Recurring"
+	BacsRegular   BacsPaymentType = "Regular"
+)
+
+// SepaMandateType is the type of SEPA mandate.
+type SepaMandateType string
+
+const (
+	SepaMandateCore SepaMandateType = "Core"
+	SepaMandateB2B  SepaMandateType = "B2B"
+)
+
+// AchAccountType is the type of Direct Debit account of an ACH instrument.
+//
+// Distinct from common.AccountType, which declares savings, current and cash for the bank-account
+// instrument. The ACH field declares savings and checking.
+type AchAccountType string
+
+const (
+	AchSavings  AchAccountType = "savings"
+	AchChecking AchAccountType = "checking"
+)
+
+// InstrumentAccountHolderType is the type of account holder on a stored instrument.
+//
+// The instrument schemas declare individual and corporate only, unlike common.AccountHolderType.
+type InstrumentAccountHolderType string
+
+const (
+	InstrumentAccountHolderIndividual InstrumentAccountHolderType = "individual"
+	InstrumentAccountHolderCorporate  InstrumentAccountHolderType = "corporate"
+)
+
+// SepaBillingAddress is the billing address of the account holder of a SEPA instrument.
+//
+// AddressLine1 max 200, AddressLine2 max 10 and Country min 2 max 2 characters. City and Zip are
+// max 35 and max 16 when storing, and max 50 both when updating.
+type SepaBillingAddress struct {
+	AddressLine1 string         `json:"address_line1,omitempty"`
+	AddressLine2 string         `json:"address_line2,omitempty"`
+	City         string         `json:"city,omitempty"`
+	Zip          string         `json:"zip,omitempty"`
+	Country      common.Country `json:"country,omitempty"`
+}
+
+// SepaAccountHolder is the account holder details of a SEPA instrument.
+//
+// The schema declares these five properties only. Deliberately not common.AccountHolder, which is a
+// superset carrying a phone, identification, a date of birth and a tax ID this schema does not
+// declare.
+type SepaAccountHolder struct {
+	FirstName      string                      `json:"first_name,omitempty"`
+	LastName       string                      `json:"last_name,omitempty"`
+	CompanyName    string                      `json:"company_name,omitempty"`
+	BillingAddress *SepaBillingAddress         `json:"billing_address,omitempty"`
+	Type           InstrumentAccountHolderType `json:"type,omitempty"`
+}
+
+// InstrumentData is the details of a SEPA account.
+//
+// AccountNumber is the IBAN, min 15 max 34 characters. MandateId min 1 max 35 characters.
+// DateOfSignature is required when MandateId is provided and defaults to the current date otherwise.
 type InstrumentData struct {
+	Type            SepaMandateType      `json:"type,omitempty"`
 	AccountNumber   string               `json:"account_number,omitempty"`
 	Country         common.Country       `json:"country,omitempty"`
 	Currency        common.Currency      `json:"currency,omitempty"`
-	PaymentType     payments.PaymentType `json:"payment_type,omitempty"`
+	PaymentType     SepaPaymentType      `json:"payment_type,omitempty"`
 	MandateId       string               `json:"mandate_id,omitempty"`
 	DateOfSignature *common.APIShortDate `json:"date_of_signature,omitempty"`
 }
 
+// AchAccountHolder is the account holder details of an ACH instrument.
+//
+// The schema marks all four properties required, but the descriptions qualify that: the names apply
+// to an individual account holder and the company name to a corporate one. The ACH account holder
+// declares no billing address.
+type AchAccountHolder struct {
+	FirstName   string                      `json:"first_name,omitempty"`
+	LastName    string                      `json:"last_name,omitempty"`
+	CompanyName string                      `json:"company_name,omitempty"`
+	Type        InstrumentAccountHolderType `json:"type,omitempty"`
+}
+
+// AchInstrumentData is the details of an ACH bank account.
+//
+// AccountNumber min 4 max 17 characters. BankCode is the routing number, min 8 max 9 characters.
 type AchInstrumentData struct {
-	AccountType   string          `json:"account_type,omitempty"`
+	AccountType   AchAccountType  `json:"account_type,omitempty"`
 	AccountNumber string          `json:"account_number,omitempty"`
 	BankCode      string          `json:"bank_code,omitempty"`
 	Currency      common.Currency `json:"currency,omitempty"`
 	Country       common.Country  `json:"country,omitempty"`
+}
+
+// BacsBillingAddress is the billing address of the account holder of a Bacs Direct Debit instrument.
+//
+// AddressLine1 max 200 and AddressLine2 max 10 characters. City and Zip are max 35 and max 16 when
+// storing, and max 50 both when updating. Country is min 2 max 2 characters and is the only required
+// property when storing.
+type BacsBillingAddress struct {
+	AddressLine1 string         `json:"address_line1,omitempty"`
+	AddressLine2 string         `json:"address_line2,omitempty"`
+	City         string         `json:"city,omitempty"`
+	Zip          string         `json:"zip,omitempty"`
+	Country      common.Country `json:"country,omitempty"`
+}
+
+// CreateBacsAccountHolder is the account holder details of a Bacs instrument being stored.
+//
+// The store schema declares FirstName, LastName and BillingAddress only. It adds CompanyName and
+// Type on update, which UpdateBacsAccountHolder carries.
+type CreateBacsAccountHolder struct {
+	FirstName      string              `json:"first_name,omitempty"`
+	LastName       string              `json:"last_name,omitempty"`
+	BillingAddress *BacsBillingAddress `json:"billing_address,omitempty"`
+}
+
+// UpdateBacsAccountHolder is the account holder details of a Bacs instrument being updated.
+type UpdateBacsAccountHolder struct {
+	FirstName      string                      `json:"first_name,omitempty"`
+	LastName       string                      `json:"last_name,omitempty"`
+	CompanyName    string                      `json:"company_name,omitempty"`
+	BillingAddress *BacsBillingAddress         `json:"billing_address,omitempty"`
+	Type           InstrumentAccountHolderType `json:"type,omitempty"`
+}
+
+// BacsInstrumentAccount is the account configuration for a Bacs Direct Debit instrument.
+//
+// ProcessingChannelId matches the pattern ^(pc)_(\w{26})$.
+type BacsInstrumentAccount struct {
+	ProcessingChannelId string `json:"processing_channel_id,omitempty"`
+}
+
+// BacsInstrumentData is the details of a Bacs Direct Debit account.
+//
+// AccountNumber is min 8 max 8 characters and BankCode is the six-digit sort code. PaymentType is
+// capitalized, unlike the SEPA equivalent.
+type BacsInstrumentData struct {
+	AccountNumber     string          `json:"account_number,omitempty"`
+	BankCode          string          `json:"bank_code,omitempty"`
+	Country           common.Country  `json:"country,omitempty"`
+	Currency          common.Currency `json:"currency,omitempty"`
+	PaymentType       BacsPaymentType `json:"payment_type,omitempty"`
+	AllowPartialMatch *bool           `json:"allow_partial_match,omitempty"`
 }
 
 type ProvisionNetworkToken struct {

--- a/instruments/nas/update.go
+++ b/instruments/nas/update.go
@@ -43,13 +43,19 @@ type (
 	updateSepaInstrumentRequest struct {
 		Type           common.InstrumentType `json:"type" binding:"required"`
 		InstrumentData *InstrumentData       `json:"instrument_data,omitempty"`
-		AccountHolder  *common.AccountHolder `json:"account_holder,omitempty"`
+		AccountHolder  *SepaAccountHolder    `json:"account_holder,omitempty"`
 	}
 
 	updateAchInstrumentRequest struct {
 		Type           common.InstrumentType `json:"type" binding:"required"`
 		InstrumentData *AchInstrumentData    `json:"instrument_data,omitempty"`
-		AccountHolder  *common.AccountHolder `json:"account_holder,omitempty"`
+		AccountHolder  *AchAccountHolder     `json:"account_holder,omitempty"`
+	}
+
+	updateBacsInstrumentRequest struct {
+		Type           common.InstrumentType    `json:"type" binding:"required"`
+		InstrumentData *BacsInstrumentData      `json:"instrument_data,omitempty"`
+		AccountHolder  *UpdateBacsAccountHolder `json:"account_holder,omitempty"`
 	}
 )
 
@@ -83,6 +89,12 @@ func NewUpdateAchInstrumentRequest() *updateAchInstrumentRequest {
 	}
 }
 
+func NewUpdateBacsInstrumentRequest() *updateBacsInstrumentRequest {
+	return &updateBacsInstrumentRequest{
+		Type: common.Bacs,
+	}
+}
+
 type (
 	UpdateInstrumentResponse struct {
 		HttpMetadata                        common.HttpMetadata
@@ -90,6 +102,7 @@ type (
 		UpdateBankAccountInstrumentResponse *UpdateBankAccountInstrumentResponse
 		UpdateSepaInstrumentResponse        *UpdateSepaInstrumentResponse
 		UpdateAchInstrumentResponse         *UpdateAchInstrumentResponse
+		UpdateBacsInstrumentResponse        *UpdateBacsInstrumentResponse
 		AlternativeResponse                 *common.AlternativeResponse
 	}
 
@@ -112,6 +125,14 @@ type (
 	}
 
 	UpdateAchInstrumentResponse struct {
+		Type        common.InstrumentType `json:"type" binding:"required"`
+		Id          string                `json:"id,omitempty"`
+		Fingerprint string                `json:"fingerprint,omitempty"`
+	}
+
+	// UpdateBacsInstrumentResponse is the response returned after updating a stored Bacs Direct
+	// Debit instrument. UpdateBacsInstrumentResponse declares type, id and fingerprint.
+	UpdateBacsInstrumentResponse struct {
 		Type        common.InstrumentType `json:"type" binding:"required"`
 		Id          string                `json:"id,omitempty"`
 		Fingerprint string                `json:"fingerprint,omitempty"`
@@ -149,6 +170,12 @@ func (s *UpdateInstrumentResponse) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 		s.UpdateAchInstrumentResponse = &response
+	case string(common.Bacs):
+		var response UpdateBacsInstrumentResponse
+		if err := json.Unmarshal(data, &response); err != nil {
+			return nil
+		}
+		s.UpdateBacsInstrumentResponse = &response
 	default:
 		var response common.AlternativeResponse
 		if err := json.Unmarshal(data, &response); err != nil {

--- a/nas/checkout_api.go
+++ b/nas/checkout_api.go
@@ -3,6 +3,7 @@ package nas
 import (
 	"github.com/checkout/checkout-sdk-go/v3/accounts"
 	"github.com/checkout/checkout-sdk-go/v3/agenticcommerce"
+	"github.com/checkout/checkout-sdk-go/v3/apm/bacs"
 	"github.com/checkout/checkout-sdk-go/v3/apm/ideal"
 	"github.com/checkout/checkout-sdk-go/v3/apm/klarna"
 	"github.com/checkout/checkout-sdk-go/v3/apm/sepa"
@@ -34,7 +35,7 @@ import (
 	"github.com/checkout/checkout-sdk-go/v3/payments/hosted"
 	"github.com/checkout/checkout-sdk-go/v3/payments/links"
 	payments "github.com/checkout/checkout-sdk-go/v3/payments/nas"
-	"github.com/checkout/checkout-sdk-go/v3/payments/sessions"
+	payment_sessions "github.com/checkout/checkout-sdk-go/v3/payments/sessions"
 	"github.com/checkout/checkout-sdk-go/v3/payments/setups"
 	"github.com/checkout/checkout-sdk-go/v3/reports"
 	"github.com/checkout/checkout-sdk-go/v3/sessions"
@@ -84,6 +85,7 @@ type Api struct {
 	Ideal  *ideal.Client
 	Klarna *klarna.Client
 	Sepa   *sepa.Client
+	Bacs   *bacs.Client
 
 	OnboardingSimulator *onboardingsimulator.Client
 }
@@ -132,6 +134,7 @@ func CheckoutApi(configuration *configuration.Configuration) *Api {
 	api.Ideal = ideal.NewClient(configuration, apiClient)
 	api.Klarna = klarna.NewClient(configuration, apiClient)
 	api.Sepa = sepa.NewClient(configuration, apiClient)
+	api.Bacs = bacs.NewClient(configuration, apiClient)
 	api.OnboardingSimulator = onboardingsimulator.NewClient(configuration, apiClient)
 	return &api
 }

--- a/nas/checkout_api_test.go
+++ b/nas/checkout_api_test.go
@@ -1,0 +1,48 @@
+package nas
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/abc"
+	"github.com/checkout/checkout-sdk-go/v3/configuration"
+	"github.com/checkout/checkout-sdk-go/v3/mocks"
+)
+
+func testConfiguration() *configuration.Configuration {
+	credentials := new(mocks.CredentialsMock)
+	environment := new(mocks.EnvironmentMock)
+	enableTelemetry := true
+	environment.On("BaseUri").Return("https://api.sandbox.checkout.com")
+	environment.On("FilesUri").Return("https://files.sandbox.checkout.com")
+	environment.On("BalancesUri").Return("https://balances.sandbox.checkout.com")
+	environment.On("TransfersUri").Return("https://transfers.sandbox.checkout.com")
+	environment.On("ForwardUri").Return("https://forward.sandbox.checkout.com")
+	environment.On("IdentityUri").Return("https://identity.sandbox.checkout.com")
+	return configuration.NewConfiguration(credentials, &enableTelemetry, environment, &http.Client{}, nil)
+}
+
+// The client surface is otherwise untested, so a missing registration would leave Api.Bacs nil with
+// the whole suite green.
+func TestCheckoutApiRegistersTheBacsClient(t *testing.T) {
+	api := CheckoutApi(testConfiguration())
+
+	assert.NotNil(t, api)
+	assert.NotNil(t, api.Bacs)
+	assert.NotNil(t, api.Instruments)
+	assert.NotNil(t, api.Sepa)
+}
+
+// POST /apms/bacs/notifications is current-platform, secret-key-only, so the client must not be
+// reachable through the previous-platform Api. In Go that is a compile-time guarantee because the
+// two Api structs are independent; this pins it so a future refactor cannot merge them silently.
+func TestPreviousApiDoesNotExposeTheBacsClient(t *testing.T) {
+	_, found := reflect.TypeOf(abc.Api{}).FieldByName("Bacs")
+	assert.False(t, found)
+
+	_, found = reflect.TypeOf(Api{}).FieldByName("Bacs")
+	assert.True(t, found)
+}

--- a/payments/nas/sources/apm/ach_source_account_type_test.go
+++ b/payments/nas/sources/apm/ach_source_account_type_test.go
@@ -1,0 +1,83 @@
+package apm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/common"
+)
+
+// PaymentRequestAchSource is the only schema declaring savings / checking / cash.
+// requestAchSource previously used common.AccountType, which declares "current" instead of
+// "checking", so a valid account type could not be sent and an invalid one was offered.
+func TestAchSourceAccountTypeValues(t *testing.T) {
+	assert.Equal(t, "savings", string(AchSourceSavings))
+	assert.Equal(t, "checking", string(AchSourceChecking))
+	assert.Equal(t, "cash", string(AchSourceCash))
+}
+
+func TestAchSourceAccountTypeDiffersFromSharedAccountType(t *testing.T) {
+	// The shared enum offers Current, which this position rejects, and cannot express checking.
+	// If these are ever unified, this fails.
+	assert.Equal(t, "current", string(common.Current))
+	assert.NotEqual(t, string(common.Current), string(AchSourceChecking))
+	assert.NotEqual(t, string(common.Savings), string(AchSourceChecking))
+}
+
+func TestAchSourceSerializesCheckingAccountType(t *testing.T) {
+	source := NewRequestAchSource()
+	source.AccountType = AchSourceChecking
+	source.Country = common.US
+	source.AccountNumber = "136549956"
+	source.BankCode = "021000021"
+
+	body, err := json.Marshal(source)
+	assert.Nil(t, err)
+
+	var got map[string]interface{}
+	assert.Nil(t, json.Unmarshal(body, &got))
+
+	assert.Equal(t, "ach", got["type"])
+	assert.Equal(t, "checking", got["account_type"])
+	assert.Equal(t, "136549956", got["account_number"])
+	assert.Equal(t, "021000021", got["bank_code"])
+}
+
+func TestAchSourceSerializesEveryDeclaredAccountType(t *testing.T) {
+	for _, accountType := range []AchSourceAccountType{AchSourceSavings, AchSourceChecking, AchSourceCash} {
+		source := NewRequestAchSource()
+		source.AccountType = accountType
+
+		body, err := json.Marshal(source)
+		assert.Nil(t, err)
+
+		var got map[string]interface{}
+		assert.Nil(t, json.Unmarshal(body, &got))
+		assert.Equal(t, string(accountType), got["account_type"])
+	}
+}
+
+func TestAchSourceAccountHolderIsNarrowerThanTheSharedType(t *testing.T) {
+	source := NewRequestAchSource()
+	source.AccountType = AchSourceChecking
+	source.AccountHolder = &AchSourceAccountHolder{
+		Type:      common.Individual,
+		FirstName: "John",
+		LastName:  "Smith",
+	}
+
+	body, err := json.Marshal(source)
+	assert.Nil(t, err)
+
+	var got map[string]interface{}
+	assert.Nil(t, json.Unmarshal(body, &got))
+
+	holder := got["account_holder"].(map[string]interface{})
+	// AccountHolderAch declares seven properties. The shared common.AccountHolder carries 18,
+	// including a phone and a tax ID this position does not accept.
+	assert.Equal(t, "individual", holder["type"])
+	assert.Equal(t, "John", holder["first_name"])
+	assert.Len(t, holder, 3)
+}

--- a/payments/nas/sources/apm/apm.go
+++ b/payments/nas/sources/apm/apm.go
@@ -235,14 +235,14 @@ type (
 	}
 
 	// requestSepaSource is the SEPA Direct Debit source.
-	//
-	// BankCode is not declared by PaymentRequestSEPAV4Source. No SEPA schema in the specification
-	// declares a bank code, and the source is identified by IBAN through AccountNumber. Retained
-	// pending confirmation from the API owners that it is a supported but unlisted field.
 	requestSepaSource struct {
-		Type            payments.SourceType   `json:"type,omitempty"`
-		Country         common.Country        `json:"country,omitempty"`
-		AccountNumber   string                `json:"account_number,omitempty"`
+		Type          payments.SourceType `json:"type,omitempty"`
+		Country       common.Country      `json:"country,omitempty"`
+		AccountNumber string              `json:"account_number,omitempty"`
+		// BankCode is not declared by PaymentRequestSEPAV4Source. No SEPA schema in the
+		// specification declares a bank code, and the SEPA source is identified by IBAN through
+		// AccountNumber. Retained for retro-compatibility purposes only. Possibly an obsoleted
+		// field.
 		BankCode        string                `json:"bank_code,omitempty"`
 		Currency        common.Currency       `json:"currency,omitempty"`
 		AccountHolder   *common.AccountHolder `json:"account_holder,omitempty"`

--- a/payments/nas/sources/apm/apm.go
+++ b/payments/nas/sources/apm/apm.go
@@ -53,14 +53,93 @@ const (
 	SepaMandateB2B  SepaMandateType = "B2B"
 )
 
+// SepaSourceAccountHolderType is the type of account holder on a SEPA payment source.
+//
+// This position declares two values only, unlike common.AccountHolderType which also declares
+// "government". Send them lowercase: the specification declares them capitalized here, but every
+// other account-holder-type position declares them lowercase and every other Checkout.com SDK sends
+// lowercase. Pending confirmation from the API owners.
+type SepaSourceAccountHolderType string
+
+const (
+	SepaSourceIndividual SepaSourceAccountHolderType = "individual"
+	SepaSourceCorporate  SepaSourceAccountHolderType = "corporate"
+)
+
+// AchSourceAccountType is the type of Direct Debit account on an ACH payment source.
+//
+// PaymentRequestAchSource is the only schema declaring this set. common.AccountType is
+// savings / current / cash and serves the bank-account positions, so it cannot express "checking".
+// nas.AchAccountType is savings / checking and serves the stored ACH instrument positions, so it
+// does not declare "cash".
+type AchSourceAccountType string
+
+const (
+	AchSourceSavings  AchSourceAccountType = "savings"
+	AchSourceChecking AchSourceAccountType = "checking"
+	AchSourceCash     AchSourceAccountType = "cash"
+)
+
 type (
+	// SepaSourceBillingAddress is the account holder's billing address on a SEPA payment source.
+	//
+	// Every property is required. Deliberately not common.Address, which also declares a State that
+	// this position does not accept.
+	SepaSourceBillingAddress struct {
+		AddressLine1 string         `json:"address_line1,omitempty"`
+		AddressLine2 string         `json:"address_line2,omitempty"`
+		City         string         `json:"city,omitempty"`
+		Zip          string         `json:"zip,omitempty"`
+		Country      common.Country `json:"country,omitempty"`
+	}
+
+	// SepaSourceAccountHolder is the account holder's personal information on a SEPA payment source.
+	//
+	// Maps the account_holder object of PaymentRequestSEPAV4Source. Deliberately not
+	// common.AccountHolder, which is an 18-property superset. Only BillingAddress is required here,
+	// where the SEPA instrument requires the names too. Send Type lowercase (individual, corporate):
+	// the specification declares it capitalized at this one position, but every other
+	// account-holder-type position declares it lowercase and every other Checkout.com SDK sends
+	// lowercase. Pending confirmation from the API owners.
+	//
+	// FirstName, LastName and CompanyName are each max 50 characters.
+	SepaSourceAccountHolder struct {
+		BillingAddress *SepaSourceBillingAddress   `json:"billing_address,omitempty"`
+		FirstName      string                      `json:"first_name,omitempty"`
+		LastName       string                      `json:"last_name,omitempty"`
+		CompanyName    string                      `json:"company_name,omitempty"`
+		Type           SepaSourceAccountHolderType `json:"type,omitempty"`
+	}
+
+	// AchSourceAccountHolder is the account holder's details on an ACH payment source.
+	//
+	// Maps the AccountHolderAch schema exactly. Deliberately not common.AccountHolder, which is an
+	// 18-property superset, and distinct from the four-property ACH instrument account holder - the
+	// instrument schema declares no billing address, date of birth or identification.
+	//
+	// Type, FirstName and LastName are required. BillingAddress reuses common.Address because that
+	// schema's six properties are exactly what this position references. Identification reuses
+	// common.AccountHolderIdentification, which carries one extra property, DateOfExpiry, that this
+	// position does not declare - do not set it.
+	AchSourceAccountHolder struct {
+		Type           common.AccountHolderType            `json:"type,omitempty"`
+		FirstName      string                              `json:"first_name,omitempty"`
+		LastName       string                              `json:"last_name,omitempty"`
+		CompanyName    string                              `json:"company_name,omitempty"`
+		BillingAddress *common.Address                     `json:"billing_address,omitempty"`
+		DateOfBirth    string                              `json:"date_of_birth,omitempty"`
+		Identification *common.AccountHolderIdentification `json:"identification,omitempty"`
+	}
+
 	requestAchSource struct {
-		Type          payments.SourceType   `json:"type,omitempty"`
-		AccountType   common.AccountType    `json:"account_type,omitempty"`
-		AccountHolder *common.AccountHolder `json:"account_holder,omitempty"`
-		AccountNumber string                `json:"account_number,omitempty"`
-		BankCode      string                `json:"bank_code,omitempty"`
-		Country       common.Country        `json:"country,omitempty"`
+		Type payments.SourceType `json:"type,omitempty"`
+		// AccountType is savings, checking or cash. Deliberately not common.AccountType, which
+		// declares "current" instead of "checking" and is rejected at this position.
+		AccountType   AchSourceAccountType    `json:"account_type,omitempty"`
+		AccountHolder *AchSourceAccountHolder `json:"account_holder,omitempty"`
+		AccountNumber string                  `json:"account_number,omitempty"`
+		BankCode      string                  `json:"bank_code,omitempty"`
+		Country       common.Country          `json:"country,omitempty"`
 	}
 
 	requestAfterPaySource struct {
@@ -243,12 +322,12 @@ type (
 		// specification declares a bank code, and the SEPA source is identified by IBAN through
 		// AccountNumber. Retained for retro-compatibility purposes only. Possibly an obsoleted
 		// field.
-		BankCode        string                `json:"bank_code,omitempty"`
-		Currency        common.Currency       `json:"currency,omitempty"`
-		AccountHolder   *common.AccountHolder `json:"account_holder,omitempty"`
-		MandateId       string                `json:"mandate_id,omitempty"`
-		MandateType     SepaMandateType       `json:"mandate_type,omitempty"`
-		DateOfSignature string                `json:"date_of_signature,omitempty"`
+		BankCode        string                   `json:"bank_code,omitempty"`
+		Currency        common.Currency          `json:"currency,omitempty"`
+		AccountHolder   *SepaSourceAccountHolder `json:"account_holder,omitempty"`
+		MandateId       string                   `json:"mandate_id,omitempty"`
+		MandateType     SepaMandateType          `json:"mandate_type,omitempty"`
+		DateOfSignature string                   `json:"date_of_signature,omitempty"`
 	}
 
 	// requestBacsSource is the Bacs Direct Debit source.

--- a/payments/nas/sources/apm/apm.go
+++ b/payments/nas/sources/apm/apm.go
@@ -41,6 +41,18 @@ type (
 )
 
 // Requests
+// SepaMandateType is the type of SEPA mandate on a SEPA payment source.
+//
+// This deliberately does not reuse instruments/nas.SepaMandateType. The two carry the same two
+// values today, but they belong to independent schemas: this one to
+// PaymentRequestSEPAV4Source.mandate_type, the other to the SEPA instrument's instrument_data.type.
+type SepaMandateType string
+
+const (
+	SepaMandateCore SepaMandateType = "Core"
+	SepaMandateB2B  SepaMandateType = "B2B"
+)
+
 type (
 	requestAchSource struct {
 		Type          payments.SourceType   `json:"type,omitempty"`
@@ -222,6 +234,11 @@ type (
 		BillingAddress *common.Address     `json:"billing_address,omitempty"`
 	}
 
+	// requestSepaSource is the SEPA Direct Debit source.
+	//
+	// BankCode is not declared by PaymentRequestSEPAV4Source. No SEPA schema in the specification
+	// declares a bank code, and the source is identified by IBAN through AccountNumber. Retained
+	// pending confirmation from the API owners that it is a supported but unlisted field.
 	requestSepaSource struct {
 		Type            payments.SourceType   `json:"type,omitempty"`
 		Country         common.Country        `json:"country,omitempty"`
@@ -230,7 +247,16 @@ type (
 		Currency        common.Currency       `json:"currency,omitempty"`
 		AccountHolder   *common.AccountHolder `json:"account_holder,omitempty"`
 		MandateId       string                `json:"mandate_id,omitempty"`
+		MandateType     SepaMandateType       `json:"mandate_type,omitempty"`
 		DateOfSignature string                `json:"date_of_signature,omitempty"`
+	}
+
+	// requestBacsSource is the Bacs Direct Debit source.
+	//
+	// Id is the Bacs Direct Debit instrument ID and matches the pattern ^(src)_(\w{26})$.
+	requestBacsSource struct {
+		Type payments.SourceType `json:"type,omitempty"`
+		Id   string              `json:"id,omitempty"`
 	}
 
 	requestStcPaySource struct {
@@ -590,6 +616,14 @@ func NewRequestSepaSource() *requestSepaSource {
 }
 
 func (s *requestSepaSource) GetType() payments.SourceType {
+	return s.Type
+}
+
+func NewRequestBacsSource() *requestBacsSource {
+	return &requestBacsSource{Type: payments.BacsSource}
+}
+
+func (s *requestBacsSource) GetType() payments.SourceType {
 	return s.Type
 }
 

--- a/payments/nas/sources/apm/bacs_source_test.go
+++ b/payments/nas/sources/apm/bacs_source_test.go
@@ -1,0 +1,51 @@
+package apm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/payments"
+)
+
+// Schema validation tests for requestBacsSource against PaymentRequestBacsSource, which declares a
+// type and an id only, and for the SEPA source's mandate_type.
+
+func TestRequestBacsSourceSerializesTypeAndId(t *testing.T) {
+	s := NewRequestBacsSource()
+	s.Id = "src_wmlfc3zyhqzehihu7giusaaawu"
+
+	raw, err := json.Marshal(s)
+	assert.Nil(t, err)
+
+	var body map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &body))
+
+	assert.Equal(t, "bacs", body["type"])
+	assert.Equal(t, "src_wmlfc3zyhqzehihu7giusaaawu", body["id"])
+	assert.Len(t, body, 2)
+	assert.Equal(t, payments.BacsSource, s.GetType())
+}
+
+func TestRequestSepaSourceCarriesTheMandateType(t *testing.T) {
+	s := NewRequestSepaSource()
+	s.MandateType = SepaMandateB2B
+
+	raw, err := json.Marshal(s)
+	assert.Nil(t, err)
+
+	var body map[string]interface{}
+	assert.Nil(t, json.Unmarshal(raw, &body))
+
+	assert.Equal(t, "sepa", body["type"])
+	assert.Equal(t, "B2B", body["mandate_type"])
+}
+
+func TestSourceTypeCarriesTheFourAddedValues(t *testing.T) {
+	// bacs, mobilepay, swish and vipps are declared by PaymentRequestSourceType and were missing.
+	assert.Equal(t, "bacs", string(payments.BacsSource))
+	assert.Equal(t, "mobilepay", string(payments.MobilepaySource))
+	assert.Equal(t, "swish", string(payments.SwishSource))
+	assert.Equal(t, "vipps", string(payments.VippsSource))
+}

--- a/payments/sources.go
+++ b/payments/sources.go
@@ -4,6 +4,7 @@ type SourceType string
 
 const (
 	AchSource             SourceType = "ach"
+	BacsSource            SourceType = "bacs"
 	Afterpay              SourceType = "afterpay"
 	AlipayCn              SourceType = "alipay_cn"
 	AlipayHk              SourceType = "alipay_hk"
@@ -36,6 +37,7 @@ const (
 	KlarnaSource          SourceType = "klarna"
 	KnetSource            SourceType = "knet"
 	Mbway                 SourceType = "mbway"
+	MobilepaySource       SourceType = "mobilepay"
 	MultiBancoSource      SourceType = "multibanco"
 	NetworkTokenSource    SourceType = "network_token"
 	OxxoSource            SourceType = "oxxo"
@@ -53,6 +55,8 @@ const (
 	SepaSource            SourceType = "sepa"
 	SequraSource          SourceType = "sequra"
 	SofortSource          SourceType = "sofort"
+	SwishSource           SourceType = "swish"
+	VippsSource           SourceType = "vipps"
 	Stcpay                SourceType = "stcpay"
 	TamaraSource          SourceType = "tamara"
 	TabbySource           SourceType = "tabby"

--- a/test/bacs_test.go
+++ b/test/bacs_test.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkout/checkout-sdk-go/v3/apm/bacs"
+	"github.com/checkout/checkout-sdk-go/v3/common"
+)
+
+func TestSendBacsNotification(t *testing.T) {
+	t.Skip("Requires a merchant enabled for Bacs Direct Debit and an existing Bacs instrument")
+
+	collectionDate := common.APIShortDate(time.Now().AddDate(0, 0, 14))
+
+	request := bacs.NotificationRequest{
+		SourceId:          "src_wmlfc3zyhqzehihu7giusaaawu",
+		NotificationType:  bacs.AdvanceNotice,
+		CollectionDate:    &collectionDate,
+		Amount:            4999,
+		Currency:          common.GBP,
+		CustomerEmail:     "customer@example.com",
+		BillingDescriptor: "CHECKOUT",
+		SupportEmail:      "support@test.com",
+	}
+
+	response, err := DefaultApi().Bacs.SendNotification(request)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.NotEmpty(t, response.EventId)
+}

--- a/test/instruments_test.go
+++ b/test/instruments_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/checkout/checkout-sdk-go/v3/common"
 	"github.com/checkout/checkout-sdk-go/v3/errors"
 	"github.com/checkout/checkout-sdk-go/v3/instruments/nas"
-	"github.com/checkout/checkout-sdk-go/v3/payments"
 	"github.com/checkout/checkout-sdk-go/v3/tokens"
 )
 
@@ -227,14 +226,19 @@ func createSepaInstrument(t *testing.T) *nas.CreateSepaInstrumentResponse {
 		AccountNumber:   "FR7630006000011234567890189",
 		Country:         common.FR,
 		Currency:        common.EUR,
-		PaymentType:     payments.Recurring,
+		PaymentType:     nas.SepaRecurring,
 		DateOfSignature: dateOfSignature,
 	}
-	request.AccountHolder = &common.AccountHolder{
-		FirstName:      "Ali",
-		LastName:       "Farid",
-		BillingAddress: Address(),
-		Phone:          Phone(),
+	request.AccountHolder = &nas.SepaAccountHolder{
+		FirstName: "Ali",
+		LastName:  "Farid",
+		BillingAddress: &nas.SepaBillingAddress{
+			AddressLine1: "Cloverfield St.",
+			AddressLine2: "23A",
+			City:         "London",
+			Zip:          "SW1A 1AA",
+			Country:      common.GB,
+		},
 	}
 
 	response, err := DefaultApi().Instruments.Create(request)

--- a/test/payments_request_apm_test.go
+++ b/test/payments_request_apm_test.go
@@ -646,7 +646,18 @@ func getSepaSource() payments.PaymentSource {
 	source.BankCode = "37040044"
 	source.MandateId = "man_12321233211"
 	source.DateOfSignature = "2023-01-01"
-	source.AccountHolder = AccountHolder()
+	source.AccountHolder = &apm.SepaSourceAccountHolder{
+		FirstName: "John",
+		LastName:  "Smith",
+		Type:      apm.SepaSourceIndividual,
+		BillingAddress: &apm.SepaSourceBillingAddress{
+			AddressLine1: "Cloverfield St.",
+			AddressLine2: "23A",
+			City:         "London",
+			Zip:          "SW1A 1AA",
+			Country:      common.GB,
+		},
+	}
 
 	return source
 }


### PR DESCRIPTION
### Breaking changes (check at the end <img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" />)

This pull request adds full support for Bacs Direct Debit instruments and pre-notification flows to the SDK. It introduces new types, serialization logic, and client methods for Bacs, along with comprehensive tests. Additionally, it makes minor corrections and clarifications to instrument type handling and updates related SEPA and ACH logic.

### Bacs Direct Debit support

* Adds the `bacs` package, including `NotificationRequest` and `NotificationResponse` types, constants, and serialization rules for Bacs pre-notification requests (`bacs.go`).
* Implements the `Client` for Bacs, providing `SendNotification` and `SendNotificationWithContext` methods to POST Bacs pre-notifications (`client.go`).
* Adds test coverage for Bacs notification serialization and required/optional field handling (`bacs_serialization_test.go`).
* Adds client tests for sending Bacs notifications, covering both success and error cases (`client_test.go`).

### Instrument type and schema changes

* Introduces the `Bacs` instrument type to `common.InstrumentType` and clarifies that `CardToken` is legacy-only (`common.go`).
* Adds Bacs instrument request/response types and serialization logic to the NAS package, with schema validation tests for Bacs, SEPA, and ACH instruments (`bacs_serialization_test.go`, `create.go`). [[1]](diffhunk://#diff-17b8f69b90cc4c658593ee9d4859db2e30f989a8e883deb91e83a13f61e601f2R1-R290) [[2]](diffhunk://#diff-e41922b8068887bcc967573051a7178640d288dfbdb2e1f14c7907bac0baa598L51-R66) [[3]](diffhunk://#diff-e41922b8068887bcc967573051a7178640d288dfbdb2e1f14c7907bac0baa598R101-R106)

### SEPA and ACH instrument improvements

* Ensures SEPA and ACH instrument requests use their specific account holder types, not the generic one, and corrects the test to use the proper payment type constant (`create.go`, `client_test.go`). [[1]](diffhunk://#diff-e41922b8068887bcc967573051a7178640d288dfbdb2e1f14c7907bac0baa598L51-R66) [[2]](diffhunk://#diff-c2a686ec6e5a7e11e580c410ac46e4e01e1dc5d2d740ed07038918857e515828L249-R248)
* Removes an unused import of `payments` from `client_test.go`.

### Breaking changes <img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" /><img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" /><img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" />

In Go a major bump also requires the module path suffix, so `go.mod` becomes
`github.com/checkout/checkout-sdk-go/v4` and every import path changes with it. That is deliberately
**not** in this PR — it landed as its own mechanical commit for v3 (`chore!: declare the v3 module
path (#245)`) and should follow the same pattern here, ahead of the tag.

The instruments models were reshaped so each scheme (SEPA, Bacs, ACH) has its own value types.
Previously a single `InstrumentData` served SEPA while the shared `common.AccountHolder` was reused on
schemas that declare a fraction of its fields.

Nothing was removed. All seven breaking changes are **retypes**, so they surface as compile errors
rather than silent behaviour changes.

#### Retyped fields

| Type | Field | Before | After |
|---|---|---|---|
| `InstrumentData` | `PaymentType` | `payments.PaymentType` | `SepaPaymentType` |
| `AchInstrumentData` | `AccountType` | `string` | `AchAccountType` |
| `createSepaInstrumentRequest` | `AccountHolder` | `*common.AccountHolder` | `*SepaAccountHolder` |
| `updateSepaInstrumentRequest` | `AccountHolder` | `*common.AccountHolder` | `*SepaAccountHolder` |
| `createAchInstrumentRequest` | `AccountHolder` | `*common.AccountHolder` | `*AchAccountHolder` |
| `updateAchInstrumentRequest` | `AccountHolder` | `*common.AccountHolder` | `*AchAccountHolder` |
| `GetAchInstrumentResponse` | `AccountHolder` | `*common.AccountHolder` | `*AchAccountHolder` |

The four request structs are unexported, but callers reach them through
`NewCreateSepaInstrumentRequest()` and friends and assign to the exported fields, so these are real
breaks at the call site.

#### Three of these were live defects, not tidying:

1. **SEPA `payment_type` sent a value the API rejects.** `InstrumentData.PaymentType` was
   `payments.PaymentType`, whose values are capitalised (`Regular`, `Recurring`). The specification
   declares the SEPA field lowercase, so anyone following the type was sending a rejected value. Split
   into `SepaPaymentType` (lowercase) and `BacsPaymentType` (capitalised, which is what Bacs Direct
   Debit genuinely uses). A regression test pins both so they cannot be unified again.
2. **The SEPA mandate type could not be sent at all.** `InstrumentData` had no field for
   `instrument_data.type`, so `Core` / `B2B` was unreachable. Go was the only SDK missing it.
3. **`AchInstrumentData.AccountType` was an untyped `string`** and `checking` existed nowhere in the
   SDK. It is now `AchAccountType` (`savings`, `checking`), deliberately distinct from
   `common.AccountType` (`savings`, `current`, `cash`) — sharing that type would let callers pass
   `current` or `cash`, which the ACH field rejects.

The account-holder retypes are the same over-exposure fix applied in the other SDKs:
`common.AccountHolder` carries a phone, identification, a date of birth and a tax ID that neither the
SEPA nor the ACH instrument schema declares. The ACH account holder declares no billing address at
all.

#### Migration

```go
// Before
r := nas.NewCreateSepaInstrumentRequest()
r.InstrumentData = &nas.InstrumentData{
    AccountNumber: "FR2810096000509685512959O86",
    Country:       common.FR,
    Currency:      common.EUR,
    PaymentType:   payments.Recurring,        // sent "Recurring" - rejected
    MandateId:     "1234567890",
}
r.AccountHolder = &common.AccountHolder{
    FirstName:      "John",
    LastName:       "Wick",
    Phone:          phone,                    // not in the SEPA schema
    BillingAddress: address,
}

// After
r := nas.NewCreateSepaInstrumentRequest()
r.InstrumentData = &nas.InstrumentData{
    Type:          nas.SepaMandateCore,       // new: was unreachable before
    AccountNumber: "FR2810096000509685512959O86",
    Country:       common.FR,
    Currency:      common.EUR,
    PaymentType:   nas.SepaRecurring,         // sends "recurring"
    MandateId:     "1234567890",
}
r.AccountHolder = &nas.SepaAccountHolder{
    FirstName: "John",
    LastName:  "Wick",
    BillingAddress: &nas.SepaBillingAddress{
        AddressLine1: "Evergreen Terrace",
        AddressLine2: "742",
        City:         "Paris",
        Zip:          "75000",
        Country:      common.FR,
    },
}