### PR TITLE
Feature/int 1692 - Top-up instructions and amount allocations

### DIFF
--- a/balances/balances.go
+++ b/balances/balances.go
@@ -51,10 +51,8 @@ type (
 	}
 )
 
-// TopUpInstructionsResponse is the response of
+// Response types for
 // GET /entities/{entityId}/currency-accounts/{currencyAccountId}/top-up-instructions.
-//
-// It carries the bank details and payment reference used to top up a sub-account.
 type (
 	// TopUpFundingDetails holds the bank details for a single funding rail.
 	//
@@ -109,8 +107,10 @@ type (
 		International *TopUpFundingDetails `json:"international,omitempty"`
 	}
 
-	// TopUpInstructionsResponse is the bank details and payment reference used to top up a
-	// sub-account.
+	// TopUpInstructionsResponse is the response of
+	// GET /entities/{entityId}/currency-accounts/{currencyAccountId}/top-up-instructions.
+	//
+	// It carries the bank details and payment reference used to top up a sub-account.
 	TopUpInstructionsResponse struct {
 		HttpMetadata common.HttpMetadata
 		// CurrencyAccountId is the unique identifier of the sub-account that the instructions

--- a/balances/balances.go
+++ b/balances/balances.go
@@ -7,7 +7,10 @@ import (
 )
 
 const (
-	balances = "balances"
+	balances          = "balances"
+	entities          = "entities"
+	currencyAccounts  = "currency-accounts"
+	topUpInstructions = "top-up-instructions"
 )
 
 type (
@@ -45,5 +48,87 @@ type (
 	QueryResponse struct {
 		HttpMetadata common.HttpMetadata
 		Data         []AccountBalance `json:"data,omitempty"`
+	}
+)
+
+// TopUpInstructionsResponse is the response of
+// GET /entities/{entityId}/currency-accounts/{currencyAccountId}/top-up-instructions.
+//
+// It carries the bank details and payment reference used to top up a sub-account.
+type (
+	// TopUpFundingDetails holds the bank details for a single funding rail.
+	//
+	// BeneficiaryAccountName and BankName are the only fields always returned. The remaining
+	// fields vary by rail and the receiving bank's jurisdiction, and are omitted when they do
+	// not apply.
+	TopUpFundingDetails struct {
+		// BeneficiaryAccountName is the name of the account that receives the funds.
+		// [Required]
+		BeneficiaryAccountName string `json:"beneficiary_account_name,omitempty"`
+		// BeneficiaryAddress is the address of the beneficiary, if the rail requires it.
+		// [Optional]
+		BeneficiaryAddress string `json:"beneficiary_address,omitempty"`
+		// BankName is the name of the bank that receives the funds.
+		// [Required]
+		BankName string `json:"bank_name,omitempty"`
+		// BankAddress is the address of the receiving bank, if the rail requires it.
+		// [Optional]
+		BankAddress string `json:"bank_address,omitempty"`
+		// AccountNumber is the account number of the receiving account.
+		// [Optional]
+		AccountNumber string `json:"account_number,omitempty"`
+		// SortCode is the sort code of the receiving bank. Returned for United Kingdom
+		// domestic transfers.
+		// [Optional]
+		SortCode string `json:"sort_code,omitempty"`
+		// RoutingNumber is the routing number of the receiving bank. Returned for United
+		// States domestic transfers.
+		// [Optional]
+		RoutingNumber string `json:"routing_number,omitempty"`
+		// Iban is the International Bank Account Number of the receiving account.
+		// [Optional]
+		Iban string `json:"iban,omitempty"`
+		// SwiftCode is the SWIFT or BIC code of the receiving bank. Returned for
+		// international transfers.
+		// [Optional]
+		SwiftCode string `json:"swift_code,omitempty"`
+	}
+
+	// TopUpBankDetails holds the bank details for each available funding rail.
+	//
+	// Both Domestic and International are optional, and their availability depends on the
+	// sub-account's holding currency, jurisdiction, and banking partner. Do not assume that
+	// both rails are always available. Both are pointers so an absent rail is distinguishable
+	// from a rail returned with empty fields.
+	TopUpBankDetails struct {
+		// Domestic holds the bank details for the domestic funding rail.
+		// [Optional]
+		Domestic *TopUpFundingDetails `json:"domestic,omitempty"`
+		// International holds the bank details for the international funding rail.
+		// [Optional]
+		International *TopUpFundingDetails `json:"international,omitempty"`
+	}
+
+	// TopUpInstructionsResponse is the bank details and payment reference used to top up a
+	// sub-account.
+	TopUpInstructionsResponse struct {
+		HttpMetadata common.HttpMetadata
+		// CurrencyAccountId is the unique identifier of the sub-account that the instructions
+		// apply to.
+		// [Required]
+		CurrencyAccountId string `json:"currency_account_id,omitempty"`
+		// Currency is the currency that funds must be sent in, as a three-letter ISO 4217
+		// currency code. This is the sub-account's holding currency, returned as
+		// holding_currency by the Retrieve entity balances endpoint.
+		// [Required]
+		Currency common.Currency `json:"currency,omitempty"`
+		// PaymentReference is the reference that must be quoted on the payment. It is how an
+		// incoming payment is attributed to the sub-account. A payment sent without this
+		// reference may not be credited.
+		// [Required]
+		PaymentReference string `json:"payment_reference,omitempty"`
+		// BankDetails holds the bank details for each available funding rail.
+		// [Required]
+		BankDetails *TopUpBankDetails `json:"bank_details,omitempty"`
 	}
 )

--- a/balances/client.go
+++ b/balances/client.go
@@ -2,10 +2,12 @@ package balances
 
 import (
 	"context"
+	"strings"
 
 	"github.com/checkout/checkout-sdk-go/v3/client"
 	"github.com/checkout/checkout-sdk-go/v3/common"
 	"github.com/checkout/checkout-sdk-go/v3/configuration"
+	"github.com/checkout/checkout-sdk-go/v3/errors"
 )
 
 type Client struct {
@@ -64,6 +66,9 @@ func (c *Client) RetrieveEntityBalancesWithContext(
 // entityId is the ID of the entity that owns the sub-account, or of an entity above it in your
 // hierarchy; a platform can use its own entity ID to reach the sub-accounts of any entity beneath
 // it. currencyAccountId is the ID of the sub-account to retrieve top-up instructions for.
+//
+// Both arguments are required. A blank value for either returns a CheckoutArgumentError without
+// making a request, matching the java and .NET SDKs' validateParams semantics.
 func (c *Client) RetrieveTopUpInstructions(entityId, currencyAccountId string) (*TopUpInstructionsResponse, error) {
 	return c.RetrieveTopUpInstructionsWithContext(context.Background(), entityId, currencyAccountId)
 }
@@ -73,6 +78,13 @@ func (c *Client) RetrieveTopUpInstructionsWithContext(
 	ctx context.Context,
 	entityId, currencyAccountId string,
 ) (*TopUpInstructionsResponse, error) {
+	if strings.TrimSpace(entityId) == "" {
+		return nil, errors.CheckoutArgumentError("entityId cannot be blank")
+	}
+	if strings.TrimSpace(currencyAccountId) == "" {
+		return nil, errors.CheckoutArgumentError("currencyAccountId cannot be blank")
+	}
+
 	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
 	if err != nil {
 		return nil, err

--- a/balances/client.go
+++ b/balances/client.go
@@ -53,3 +53,42 @@ func (c *Client) RetrieveEntityBalancesWithContext(
 
 	return &response, nil
 }
+
+// RetrieveTopUpInstructions retrieves the bank details required to top up a sub-account, along
+// with the payment reference that attributes an incoming payment to that sub-account.
+//
+// Note: The sub-account is referred to as currency account in the API.
+//
+// GET /entities/{entityId}/currency-accounts/{currencyAccountId}/top-up-instructions
+//
+// entityId is the ID of the entity that owns the sub-account, or of an entity above it in your
+// hierarchy; a platform can use its own entity ID to reach the sub-accounts of any entity beneath
+// it. currencyAccountId is the ID of the sub-account to retrieve top-up instructions for.
+func (c *Client) RetrieveTopUpInstructions(entityId, currencyAccountId string) (*TopUpInstructionsResponse, error) {
+	return c.RetrieveTopUpInstructionsWithContext(context.Background(), entityId, currencyAccountId)
+}
+
+// RetrieveTopUpInstructionsWithContext is RetrieveTopUpInstructions with a caller-supplied context.
+func (c *Client) RetrieveTopUpInstructionsWithContext(
+	ctx context.Context,
+	entityId, currencyAccountId string,
+) (*TopUpInstructionsResponse, error) {
+	auth, err := c.configuration.Credentials.GetAuthorization(configuration.SecretKeyOrOauth)
+	if err != nil {
+		return nil, err
+	}
+
+	var response TopUpInstructionsResponse
+	err = c.apiClient.GetWithContext(
+		ctx,
+		common.BuildPath(entities, entityId, currencyAccounts, currencyAccountId, topUpInstructions),
+		auth,
+		nil,
+		&response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/balances/top_up_instructions_test.go
+++ b/balances/top_up_instructions_test.go
@@ -63,6 +63,16 @@ func assertFullRail(t *testing.T, rail *TopUpFundingDetails) {
 	assert.Equal(t, "TESTUS00XXX", rail.SwiftCode)
 }
 
+func okAuthorization(m *mock.Mock) mock.Call {
+	return *m.On("GetAuthorization", mock.Anything).
+		Return(&configuration.SdkAuthorization{}, nil)
+}
+
+func okApiGet(m *mock.Mock) mock.Call {
+	return *m.On("GetWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+}
+
 func TestRetrieveTopUpInstructions(t *testing.T) {
 	var response = TopUpInstructionsResponse{
 		HttpMetadata:      mocks.HttpMetadataStatusOk,
@@ -151,6 +161,56 @@ func TestRetrieveTopUpInstructions(t *testing.T) {
 				assert.NotNil(t, err)
 				chkErr := err.(errors.CheckoutAPIError)
 				assert.Equal(t, http.StatusForbidden, chkErr.StatusCode)
+			},
+		},
+		{
+			name:              "when entity id is empty then return argument error",
+			entityId:          "",
+			currencyAccountId: testCurrencyAccountId,
+			getAuthorization:  okAuthorization,
+			apiGet:            okApiGet,
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				assert.IsType(t, errors.CheckoutArgumentError(""), err)
+				assert.Equal(t, "entityId cannot be blank", err.Error())
+			},
+		},
+		{
+			name:              "when currency account id is empty then return argument error",
+			entityId:          testEntityId,
+			currencyAccountId: "",
+			getAuthorization:  okAuthorization,
+			apiGet:            okApiGet,
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				assert.IsType(t, errors.CheckoutArgumentError(""), err)
+				assert.Equal(t, "currencyAccountId cannot be blank", err.Error())
+			},
+		},
+		{
+			name:              "when entity id is whitespace only then return argument error",
+			entityId:          "   ",
+			currencyAccountId: testCurrencyAccountId,
+			getAuthorization:  okAuthorization,
+			apiGet:            okApiGet,
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				assert.Equal(t, "entityId cannot be blank", err.Error())
+			},
+		},
+		{
+			name:              "when both path parameters are blank then reject on entity id first",
+			entityId:          "",
+			currencyAccountId: "",
+			getAuthorization:  okAuthorization,
+			apiGet:            okApiGet,
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				assert.Equal(t, "entityId cannot be blank", err.Error())
 			},
 		},
 	}

--- a/balances/top_up_instructions_test.go
+++ b/balances/top_up_instructions_test.go
@@ -1,0 +1,320 @@
+package balances
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/checkout/checkout-sdk-go/v3/common"
+	"github.com/checkout/checkout-sdk-go/v3/configuration"
+	"github.com/checkout/checkout-sdk-go/v3/errors"
+	"github.com/checkout/checkout-sdk-go/v3/mocks"
+)
+
+const (
+	testEntityId          = "ent_w4jelhppmfiufdnatam37wrfc4"
+	testCurrencyAccountId = "ca_g5y7d6jo4e2urgforcbf2ey5jm"
+	// The exact path the SDK must build. common.BuildPath prefixes each segment with "/".
+	expectedTopUpPath = "/entities/" + testEntityId + "/currency-accounts/" + testCurrencyAccountId +
+		"/top-up-instructions"
+)
+
+// fullRailJson and the payloads below use the field-level "example" values from
+// shared/swagger-latest.json. The response schema carries no top-level example.
+const fullRailJson = `{
+	"beneficiary_account_name": "Acme Inc",
+	"beneficiary_address": "1 Example Street, Exampleville, EX, 00000, US",
+	"bank_name": "Example Bank",
+	"bank_address": "1 Example Street, Exampleville, EX, 00000, US",
+	"account_number": "1234567890",
+	"sort_code": "000000",
+	"routing_number": "000000000",
+	"iban": "GB00EXAM00000000000000",
+	"swift_code": "TESTUS00XXX"
+}`
+
+func fullRail() *TopUpFundingDetails {
+	return &TopUpFundingDetails{
+		BeneficiaryAccountName: "Acme Inc",
+		BeneficiaryAddress:     "1 Example Street, Exampleville, EX, 00000, US",
+		BankName:               "Example Bank",
+		BankAddress:            "1 Example Street, Exampleville, EX, 00000, US",
+		AccountNumber:          "1234567890",
+		SortCode:               "000000",
+		RoutingNumber:          "000000000",
+		Iban:                   "GB00EXAM00000000000000",
+		SwiftCode:              "TESTUS00XXX",
+	}
+}
+
+func assertFullRail(t *testing.T, rail *TopUpFundingDetails) {
+	assert.NotNil(t, rail)
+	assert.Equal(t, "Acme Inc", rail.BeneficiaryAccountName)
+	assert.Equal(t, "1 Example Street, Exampleville, EX, 00000, US", rail.BeneficiaryAddress)
+	assert.Equal(t, "Example Bank", rail.BankName)
+	assert.Equal(t, "1 Example Street, Exampleville, EX, 00000, US", rail.BankAddress)
+	assert.Equal(t, "1234567890", rail.AccountNumber)
+	assert.Equal(t, "000000", rail.SortCode)
+	assert.Equal(t, "000000000", rail.RoutingNumber)
+	assert.Equal(t, "GB00EXAM00000000000000", rail.Iban)
+	assert.Equal(t, "TESTUS00XXX", rail.SwiftCode)
+}
+
+func TestRetrieveTopUpInstructions(t *testing.T) {
+	var response = TopUpInstructionsResponse{
+		HttpMetadata:      mocks.HttpMetadataStatusOk,
+		CurrencyAccountId: testCurrencyAccountId,
+		Currency:          common.USD,
+		PaymentReference:  "TP-ABC123",
+		BankDetails: &TopUpBankDetails{
+			Domestic:      fullRail(),
+			International: fullRail(),
+		},
+	}
+
+	cases := []struct {
+		name              string
+		entityId          string
+		currencyAccountId string
+		getAuthorization  func(*mock.Mock) mock.Call
+		apiGet            func(*mock.Mock) mock.Call
+		checker           func(*TopUpInstructionsResponse, error)
+	}{
+		{
+			name:              "when request is correct then return top-up instructions",
+			entityId:          testEntityId,
+			currencyAccountId: testCurrencyAccountId,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				// The path is asserted here, not with mock.Anything: a wrong path is the
+				// most likely way this endpoint breaks.
+				return *m.On("GetWithContext", mock.Anything, expectedTopUpPath, mock.Anything, mock.Anything).
+					Return(nil).
+					Run(func(args mock.Arguments) {
+						respMapping := args.Get(3).(*TopUpInstructionsResponse)
+						*respMapping = response
+					})
+			},
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, err)
+				assert.NotNil(t, response)
+				assert.Equal(t, http.StatusOK, response.HttpMetadata.StatusCode)
+				assert.Equal(t, testCurrencyAccountId, response.CurrencyAccountId)
+				assert.Equal(t, common.USD, response.Currency)
+				assert.Equal(t, "TP-ABC123", response.PaymentReference)
+				assert.NotNil(t, response.BankDetails)
+				assertFullRail(t, response.BankDetails.Domestic)
+				assertFullRail(t, response.BankDetails.International)
+			},
+		},
+		{
+			name:              "when credentials invalid then return error",
+			entityId:          testEntityId,
+			currencyAccountId: testCurrencyAccountId,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(nil, errors.CheckoutAuthorizationError("Invalid authorization type"))
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				return *m.On("GetWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil)
+			},
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				assert.Equal(t, "Invalid authorization type", err.Error())
+			},
+		},
+		{
+			name:              "when top-ups are not enabled then return 403 error",
+			entityId:          testEntityId,
+			currencyAccountId: testCurrencyAccountId,
+			getAuthorization: func(m *mock.Mock) mock.Call {
+				return *m.On("GetAuthorization", mock.Anything).
+					Return(&configuration.SdkAuthorization{}, nil)
+			},
+			apiGet: func(m *mock.Mock) mock.Call {
+				return *m.On("GetWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.CheckoutAPIError{
+						StatusCode: http.StatusForbidden,
+						Status:     "403 Forbidden",
+					})
+			},
+			checker: func(response *TopUpInstructionsResponse, err error) {
+				assert.Nil(t, response)
+				assert.NotNil(t, err)
+				chkErr := err.(errors.CheckoutAPIError)
+				assert.Equal(t, http.StatusForbidden, chkErr.StatusCode)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apiClient := new(mocks.ApiClientMock)
+			credentials := new(mocks.CredentialsMock)
+			environment := new(mocks.EnvironmentMock)
+			enableTelemetry := true
+
+			tc.getAuthorization(&credentials.Mock)
+			tc.apiGet(&apiClient.Mock)
+
+			config := configuration.NewConfiguration(credentials, &enableTelemetry, environment, &http.Client{}, nil)
+			client := NewClient(config, apiClient)
+
+			tc.checker(client.RetrieveTopUpInstructions(tc.entityId, tc.currencyAccountId))
+		})
+	}
+}
+
+// --- response shape: both rails, single rail, empty bank_details ---------------
+// The spec declares no `required` array on TopUpBankDetails, so domestic-only,
+// international-only and an empty bank_details are all legal 200 bodies.
+
+func TestTopUpInstructionsResponse_UnmarshalsBothRails(t *testing.T) {
+	body := `{
+		"currency_account_id": "` + testCurrencyAccountId + `",
+		"currency": "USD",
+		"payment_reference": "TP-ABC123",
+		"bank_details": {"domestic": ` + fullRailJson + `, "international": ` + fullRailJson + `}
+	}`
+
+	var response TopUpInstructionsResponse
+	assert.Nil(t, json.Unmarshal([]byte(body), &response))
+
+	assert.Equal(t, testCurrencyAccountId, response.CurrencyAccountId)
+	assert.Equal(t, common.USD, response.Currency)
+	assert.Equal(t, "TP-ABC123", response.PaymentReference)
+	assert.NotNil(t, response.BankDetails)
+	assertFullRail(t, response.BankDetails.Domestic)
+	assertFullRail(t, response.BankDetails.International)
+}
+
+func TestTopUpInstructionsResponse_UnmarshalsDomesticOnly(t *testing.T) {
+	// A United States domestic rail, per "Returned for United States domestic transfers".
+	body := `{
+		"currency_account_id": "` + testCurrencyAccountId + `",
+		"currency": "USD",
+		"payment_reference": "TP-ABC123",
+		"bank_details": {"domestic": {
+			"beneficiary_account_name": "Acme Inc",
+			"bank_name": "Example Bank",
+			"account_number": "1234567890",
+			"routing_number": "000000000"
+		}}
+	}`
+
+	var response TopUpInstructionsResponse
+	assert.Nil(t, json.Unmarshal([]byte(body), &response))
+
+	assert.NotNil(t, response.BankDetails)
+	assert.Nil(t, response.BankDetails.International, "international rail must be nil when absent")
+	assert.NotNil(t, response.BankDetails.Domestic)
+	assert.Equal(t, "000000000", response.BankDetails.Domestic.RoutingNumber)
+	assert.Empty(t, response.BankDetails.Domestic.SortCode)
+	assert.Empty(t, response.BankDetails.Domestic.Iban)
+	assert.Empty(t, response.BankDetails.Domestic.SwiftCode)
+}
+
+func TestTopUpInstructionsResponse_UnmarshalsInternationalOnly(t *testing.T) {
+	// An international rail, per "Returned for international transfers".
+	body := `{
+		"currency_account_id": "` + testCurrencyAccountId + `",
+		"currency": "USD",
+		"payment_reference": "TP-ABC123",
+		"bank_details": {"international": {
+			"beneficiary_account_name": "Acme Inc",
+			"bank_name": "Example Bank",
+			"iban": "GB00EXAM00000000000000",
+			"swift_code": "TESTUS00XXX"
+		}}
+	}`
+
+	var response TopUpInstructionsResponse
+	assert.Nil(t, json.Unmarshal([]byte(body), &response))
+
+	assert.NotNil(t, response.BankDetails)
+	assert.Nil(t, response.BankDetails.Domestic, "domestic rail must be nil when absent")
+	assert.NotNil(t, response.BankDetails.International)
+	assert.Equal(t, "TESTUS00XXX", response.BankDetails.International.SwiftCode)
+	assert.Empty(t, response.BankDetails.International.AccountNumber)
+	assert.Empty(t, response.BankDetails.International.RoutingNumber)
+}
+
+func TestTopUpInstructionsResponse_UnmarshalsEmptyBankDetails(t *testing.T) {
+	body := `{
+		"currency_account_id": "` + testCurrencyAccountId + `",
+		"currency": "USD",
+		"payment_reference": "TP-ABC123",
+		"bank_details": {}
+	}`
+
+	var response TopUpInstructionsResponse
+	assert.Nil(t, json.Unmarshal([]byte(body), &response))
+
+	assert.NotNil(t, response.BankDetails)
+	assert.Nil(t, response.BankDetails.Domestic)
+	assert.Nil(t, response.BankDetails.International)
+}
+
+func TestTopUpInstructionsResponse_RoundTrips(t *testing.T) {
+	original := TopUpInstructionsResponse{
+		CurrencyAccountId: testCurrencyAccountId,
+		Currency:          common.USD,
+		PaymentReference:  "TP-ABC123",
+		BankDetails: &TopUpBankDetails{
+			Domestic:      fullRail(),
+			International: fullRail(),
+		},
+	}
+
+	marshalled, err := json.Marshal(original)
+	assert.Nil(t, err)
+
+	// Wire names must be snake_case.
+	body := string(marshalled)
+	for _, key := range []string{
+		`"currency_account_id"`, `"currency"`, `"payment_reference"`, `"bank_details"`,
+		`"domestic"`, `"international"`, `"beneficiary_account_name"`, `"beneficiary_address"`,
+		`"bank_name"`, `"bank_address"`, `"account_number"`, `"sort_code"`,
+		`"routing_number"`, `"iban"`, `"swift_code"`,
+	} {
+		assert.Contains(t, body, key)
+	}
+
+	var deserialized TopUpInstructionsResponse
+	assert.Nil(t, json.Unmarshal(marshalled, &deserialized))
+	assert.Equal(t, original.CurrencyAccountId, deserialized.CurrencyAccountId)
+	assert.Equal(t, original.Currency, deserialized.Currency)
+	assert.Equal(t, original.PaymentReference, deserialized.PaymentReference)
+	assertFullRail(t, deserialized.BankDetails.Domestic)
+	assertFullRail(t, deserialized.BankDetails.International)
+}
+
+func TestTopUpFundingDetails_OmitsUnsetOptionalFields(t *testing.T) {
+	marshalled, err := json.Marshal(TopUpBankDetails{
+		Domestic: &TopUpFundingDetails{
+			BeneficiaryAccountName: "Acme Inc",
+			BankName:               "Example Bank",
+		},
+	})
+	assert.Nil(t, err)
+
+	body := string(marshalled)
+	assert.Contains(t, body, `"beneficiary_account_name":"Acme Inc"`)
+	assert.Contains(t, body, `"bank_name":"Example Bank"`)
+	assert.NotContains(t, body, "international")
+	assert.NotContains(t, body, "sort_code")
+	assert.NotContains(t, body, "routing_number")
+	assert.NotContains(t, body, "iban")
+	assert.NotContains(t, body, "swift_code")
+	assert.NotContains(t, body, "beneficiary_address")
+	assert.NotContains(t, body, "bank_address")
+	assert.NotContains(t, body, "account_number")
+}

--- a/configuration/environment.go
+++ b/configuration/environment.go
@@ -141,9 +141,9 @@ func Production() *CheckoutEnv {
 	return NewEnvironment(
 		"https://api.checkout.com",
 		"https://access.checkout.com/connect/token",
-		"https://files.checkout.com/",
-		"https://transfers.checkout.com/",
-		"https://balances.checkout.com/",
+		"https://files.checkout.com",
+		"https://transfers.checkout.com",
+		"https://balances.checkout.com",
 		"https://forward.checkout.com",
 		"https://identity-verification.checkout.com",
 		false)

--- a/configuration/environment_uri_test.go
+++ b/configuration/environment_uri_test.go
@@ -1,0 +1,50 @@
+package configuration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Every SDK client builds its path with common.BuildPath, which prefixes each segment with "/".
+// A base URI that also ends in "/" therefore produces a double slash in the request URL. Sandbox
+// never had trailing slashes, so the sandbox-based test suite could not catch it; production
+// carried them on the files, transfers and balances hosts.
+func TestEnvironmentUrisHaveNoTrailingSlash(t *testing.T) {
+	cases := []struct {
+		name string
+		env  *CheckoutEnv
+	}{
+		{"Sandbox", Sandbox()},
+		{"Production", Production()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uris := map[string]string{
+				"BaseUri":      tc.env.BaseUri(),
+				"FilesUri":     tc.env.FilesUri(),
+				"TransfersUri": tc.env.TransfersUri(),
+				"BalancesUri":  tc.env.BalancesUri(),
+				"ForwardUri":   tc.env.ForwardUri(),
+				"IdentityUri":  tc.env.IdentityUri(),
+			}
+			for name, uri := range uris {
+				assert.False(t, strings.HasSuffix(uri, "/"),
+					"%s.%s must not end in \"/\" (got %q): paths already start with \"/\", so this yields a double slash",
+					tc.name, name, uri)
+			}
+		})
+	}
+}
+
+// Pins the exact URL the balances client produces in both environments.
+func TestBalancesUriJoinsCleanlyWithABuiltPath(t *testing.T) {
+	// common.BuildPath("balances", "ent_x") -> "/balances/ent_x". Inlined to avoid an import
+	// cycle between configuration and common.
+	const path = "/balances/ent_x"
+
+	assert.Equal(t, "https://balances.sandbox.checkout.com/balances/ent_x", Sandbox().BalancesUri()+path)
+	assert.Equal(t, "https://balances.checkout.com/balances/ent_x", Production().BalancesUri()+path)
+}

--- a/configuration/oauth_scopes.go
+++ b/configuration/oauth_scopes.go
@@ -4,6 +4,7 @@ const (
 	Accounts                    = "accounts"
 	Balances                    = "balances"
 	BalancesView                = "balances:view"
+	BalancesTopUpInstructions   = "balances:top-up-instructions"
 	Disputes                    = "disputes"
 	DisputesAccept              = "disputes:accept"
 	DisputesProvideEvidence     = "disputes:provide-evidence"

--- a/configuration/oauth_scopes_test.go
+++ b/configuration/oauth_scopes_test.go
@@ -1,0 +1,32 @@
+package configuration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The balances scopes are the only place the wire value of an OAuth scope is written down, and
+// nothing else in the suite exercises BalancesTopUpInstructions: the sandbox fixture's
+// getOAuthScopes() does not request it, so a typo would ship silently and every OAuth-configured
+// caller of RetrieveTopUpInstructions would be rejected at the token endpoint.
+//
+// Values are taken from components.securitySchemes.OAuth.flows.clientCredentials.scopes in
+// shared/swagger-latest.json.
+func TestBalancesOAuthScopeValues(t *testing.T) {
+	cases := []struct {
+		name     string
+		scope    string
+		expected string
+	}{
+		{"Balances", Balances, "balances"},
+		{"BalancesView", BalancesView, "balances:view"},
+		{"BalancesTopUpInstructions", BalancesTopUpInstructions, "balances:top-up-instructions"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.scope)
+		})
+	}
+}

--- a/test/configuration_api_test.go
+++ b/test/configuration_api_test.go
@@ -92,9 +92,10 @@ func TestShouldHaveCorrectProductionUrls(t *testing.T) {
 	env := configuration.Production()
 
 	assert.Equal(t, "https://api.checkout.com", env.BaseUri())
-	assert.Equal(t, "https://files.checkout.com/", env.FilesUri())
-	assert.Equal(t, "https://transfers.checkout.com/", env.TransfersUri())
-	assert.Equal(t, "https://balances.checkout.com/", env.BalancesUri())
+
+	assert.Equal(t, "https://files.checkout.com", env.FilesUri())
+	assert.Equal(t, "https://transfers.checkout.com", env.TransfersUri())
+	assert.Equal(t, "https://balances.checkout.com", env.BalancesUri())
 	assert.Equal(t, "https://forward.checkout.com", env.ForwardUri())
 	assert.Equal(t, "https://identity-verification.checkout.com", env.IdentityUri())
 }


### PR DESCRIPTION
This pull request adds support for retrieving top-up instructions for sub-accounts (currency accounts) via a new API endpoint, improves the SDK’s handling of environment URIs to avoid double slashes in URLs, and introduces comprehensive tests for both the new endpoint and environment configuration. The main changes are grouped below:

**New Top-Up Instructions Endpoint:**

* Added new types (`TopUpFundingDetails`, `TopUpBankDetails`, `TopUpInstructionsResponse`) in `balances/balances.go` to model the response structure for top-up instructions, supporting both domestic and international funding rails.
* Implemented `RetrieveTopUpInstructions` and `RetrieveTopUpInstructionsWithContext` methods in the `balances` client to call the new endpoint `GET /entities/{entityId}/currency-accounts/{currencyAccountId}/top-up-instructions`.
* Added the new OAuth scope constant `balances:top-up-instructions` in `configuration/oauth_scopes.go`.

**Testing and Validation:**

* Introduced a thorough test suite in `balances/top_up_instructions_test.go` to verify the new endpoint’s behavior, including authorization errors, response shape variations (domestic/international/empty), and JSON (un)marshalling.

**Environment URI Handling:**

* Removed trailing slashes from production environment URIs in `configuration/environment.go` to prevent double slashes in request URLs.
* Added tests in `configuration/environment_uri_test.go` to ensure environment URIs do not end with a slash and that path joining produces correct URLs.

These changes ensure robust support for the new top-up instructions feature and improve the reliability of URL construction across environments.